### PR TITLE
Add missing -p option to mkdir

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -52,7 +52,7 @@ cp -a config ./bedrock
 cd ./bedrock
 
 # This is required for the s3 filesystem
-mkdir web/app/uploads
+mkdir -p web/app/uploads
 
 # Install PHP dependencies (WordPress, plugins, etc.)
 composer install --verbose


### PR DESCRIPTION
The mkdir is failing, because the intermediate directory doesn't
exist. This should fix that.