### PR TITLE
Prevent errors from breaking REST api in dev

### DIFF
--- a/docker/config/environments/development.php
+++ b/docker/config/environments/development.php
@@ -1,5 +1,6 @@
 <?php
 /** Development */
-define('SAVEQUERIES', true);
+define('SAVEQUERIES', false);
 define('WP_DEBUG', true);
-define('SCRIPT_DEBUG', true);
+define('WP_DEBUG_DISPLAY', false);
+define('SCRIPT_DEBUG', false);


### PR DESCRIPTION
WP was displaying all errors in whatever it considered a 'page', even if
this meant putting an html snippet into a JSON response.  This change
ensures that the errors only show up in the docker logs.