### PR TITLE
Add a 'nuke-all' make target

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -13,6 +13,10 @@ nuke-images:
 nuke-assets:
 	rm -rf bedrock_volume/*
 
+nuke-all:
+	make nuke-assets
+	make nuke-images
+
 load-db-dump:
 	docker-compose -f docker-compose-dev.yml exec mysql bash -c 'cat /db-dump/*.sql | mysql -u$${MYSQL_USER} -p$${MYSQL_PASSWORD} $${MYSQL_DATABASE}'
 


### PR DESCRIPTION
This wipes the local slate clean, wrt docker images and compiled
assets (although the local data volume is left intact).