### PR TITLE
Update the WP CLI script to not remove users

### DIFF
--- a/docker/utils/prepare-local-wordpress-database.rb
+++ b/docker/utils/prepare-local-wordpress-database.rb
@@ -11,22 +11,29 @@ def main
 
   ensure_user_exists(
     login: 'regional',
-    email: 'regional@example.com',
+    email: 'mojintranettest+regional@gmail.com',
     role: 'regional-editor',
     password: ENV.fetch('pass_regional'),
     display_name: 'regional'
   )
 
+  ensure_user_exists(
+    login: 'admin',
+    email: 'admin@example.com',
+    role: 'administrator',
+    password: ENV.fetch('pass_admin'),
+    display_name: 'Administrator'
+  ) if ENV['pass_admin']
 end
 
 # The smoke tests expect certain users, some of which have been created
 # in production, but with passwords that differ from those configured in
-# the smoke tests. So, delete and recreate any user accounts we depend on.
+# the smoke tests. So, update the passwords of users we depend on.
 def ensure_user_exists(params)
   login = params.fetch(:login)
   if user_exists?(login)
-    log("User #{login} exists. Recreating")
-    delete_user(login)
+    log("User #{login} exists. Updating password.")
+    update_user_password(params)
   end
   create_user(params) unless user_exists?(login)
 end
@@ -35,8 +42,10 @@ def user_exists?(login)
   system "cd /bedrock/web; wp --allow-root user get #{login} > /dev/null 2>&1"
 end
 
-def delete_user(login)
-  system "cd /bedrock/web; wp --allow-root user delete --yes #{login} > /dev/null 2>&1"
+def update_user_password(params)
+  login = params.fetch(:login)
+  password = params.fetch(:password)
+  system "cd /bedrock/web; wp --allow-root user update #{login} --user_pass='#{password}' > /dev/null 2>&1"
 end
 
 # Create a user.


### PR DESCRIPTION
Instead of removing and recreating an already existing user, we are just
going to update their password. This way we can maintain whatever setup the
user had configured (like agencies, regions, etc.) as unfortunately wp-cli
doesn't seem to support these custom fields.

Also, if an ENV variable `pass_admin` exists, it will also create/update an
Administrator user.

As wp-cli can't seem to support setting the agencies and regions of the test
users (specifically user `agency_editor`) we need to login with an admin user
and manually asign said test user to an agency for many tests to pass.