### PR TITLE
`make restart yas3fs` -> `make restart-yas3fs`

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -33,4 +33,4 @@ restart-yas3fs:
 # seed data and user accounts
 prepare-wordpress-database:
 	docker-compose -f docker-compose-dev.yml exec wordpress /utils/prepare-local-wordpress-database.rb
-	make restart yas3fs
+	make restart-yas3fs


### PR DESCRIPTION
Fixes a typo that raises an error when running `make prepare-wordpress-database`