### PR TITLE
Fix the broken http -> https redirect on AWS

### DIFF
--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -10,85 +10,89 @@ fastcgi_cache_use_stale updating error timeout invalid_header http_500;
 fastcgi_cache_key "$real_scheme$request_method$host$request_uri";
 
 server {
-	listen 80 default_server;
+  listen 80 default_server;
 
-	root /bedrock/web;
-	index index.php;
+  root /bedrock/web;
+  index index.php;
 
-	client_max_body_size 250m;
+  client_max_body_size 250m;
 
-	include /etc/nginx/real_ip.conf;
+  include /etc/nginx/real_ip.conf;
 
-	if ($http_x_forwarded_proto = "https") {
-		set $use_ssl "on";
-	}
+  if ($http_x_forwarded_proto = "https") {
+    set $use_ssl "on";
+  }
 
-	location /wp-content/uploads/ {
-		rewrite ^/wp-content/uploads/(.*)$ /app/uploads/$1 permanent;
-	}
+  if ( $http_x_forwarded_proto != 'https' ) {
+    return 301 https://$host$request_uri;
+  }
 
-	location /wp-admin {
-		rewrite ^/wp-admin(.*)$ /wp/wp-admin$1 permanent;
-	}
+  location /wp-content/uploads/ {
+    rewrite ^/wp-content/uploads/(.*)$ /app/uploads/$1 permanent;
+  }
 
-	set $skip_cache 0;
+  location /wp-admin {
+    rewrite ^/wp-admin(.*)$ /wp/wp-admin$1 permanent;
+  }
 
-	if ($request_method = POST) {
-		set $skip_cache 1;
-	}
+  set $skip_cache 0;
 
-	if ($query_string != "") {
-		set $skip_cache 1;
-	}
+  if ($request_method = POST) {
+    set $skip_cache 1;
+  }
 
-	if ($request_uri ~* "/wp-admin/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml") {
-		set $skip_cache 1;
-	}
+  if ($query_string != "") {
+    set $skip_cache 1;
+  }
 
-	if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
-		set $skip_cache 1;
-	}
+  if ($request_uri ~* "/wp-admin/|/xmlrpc.php|wp-.*.php|/feed/|index.php|sitemap(_index)?.xml") {
+    set $skip_cache 1;
+  }
 
-	location / {
-		try_files $uri $uri/ /index.php?$args;
-	}
+  if ($http_cookie ~* "comment_author|wordpress_[a-f0-9]+|wp-postpass|wordpress_no_cache|wordpress_logged_in") {
+    set $skip_cache 1;
+  }
 
-	server_tokens off;
+  location / {
+    try_files $uri $uri/ /index.php?$args;
+  }
 
-	include /etc/nginx/whitelists/site-wide.conf;
+  server_tokens off;
 
-	location ~ /\. {
-		deny all;
-	}
+  include /etc/nginx/whitelists/site-wide.conf;
+
+  location ~ /\. {
+    deny all;
+  }
 
   location ~* /(?:uploads|files)/.*\.php$ {
-		deny all;
-	}
+    deny all;
+  }
 
-	location ~ \.php$ {
-		include /etc/nginx/php-fpm.conf;
-	}
+  location ~ \.php$ {
+    include /etc/nginx/php-fpm.conf;
+  }
 
-	location = /wp/wp-login.php {
-		limit_req zone=flood burst=5 nodelay;
+  location = /wp/wp-login.php {
+    limit_req zone=flood burst=5 nodelay;
 
-		include /etc/nginx/whitelists/wp-login.conf;
-		include /etc/nginx/php-fpm.conf;
-	}
+    include /etc/nginx/whitelists/wp-login.conf;
+    include /etc/nginx/php-fpm.conf;
+  }
 
-	location ~ /purge-cache(/.*) {
-		fastcgi_cache_purge pub01 "$real_scheme$request_method$host$1";
-	}
+  location ~ /purge-cache(/.*) {
+    fastcgi_cache_purge pub01 "$real_scheme$request_method$host$1";
+  }
 
-	location = /robots.txt { access_log off; log_not_found off; }
+  location = /robots.txt { access_log off; log_not_found off; }
 
-	gzip on;
-	gzip_disable "msie6";
+  gzip on;
+  gzip_disable "msie6";
 
-	gzip_vary on;
-	gzip_proxied any;
-	gzip_comp_level 6;
-	gzip_buffers 16 8k;
-	gzip_http_version 1.1;
-	gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/xml+rss text/javascript;
+  gzip_vary on;
+  gzip_proxied any;
+  gzip_comp_level 6;
+  gzip_buffers 16 8k;
+  gzip_http_version 1.1;
+  gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/xml+rss text/javascript;
 }


### PR DESCRIPTION
This uses the forwarded protocol header to determine if a redirect is
required, so it *shouldn't* end us up in an endless redirect loop.