### PR TITLE
Fix the overactive http -> https redirect

### DIFF
--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -23,7 +23,7 @@ server {
     set $use_ssl "on";
   }
 
-  if ( $http_x_forwarded_proto != 'https' ) {
+  if ( $http_x_forwarded_proto = "http" ) {
     return 301 https://$host$request_uri;
   }
 


### PR DESCRIPTION
It appears that `$http_x_forwarded_proto != "https"` matches when
`$https_x_forwarded_for` is not set.  This changes the rule to require
an explicit match against `http` and fixes the problem on local
container builds.

NOTE: If you've run the last version, you will need to flush your cache,
or check `http://intranet.docker` in another browser as the redirect is
permanent.