### PR TITLE
Ensure users can report additional whitelist ips

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -43,7 +43,7 @@ fi
 cp Gruntfile.js ./bedrock
 cp *.json ./bedrock
 mkdir ./bedrock/web
-cp web/*.php ./bedrock/web
+cp web/* ./bedrock/web
 cp -a config ./bedrock
 
 # Composer can build out-of-context, but the grunt cli switch to change the

--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -11,6 +11,7 @@ fastcgi_cache_key "$real_scheme$request_method$host$request_uri";
 
 server {
   listen 80 default_server;
+  error_page 403 /403.html;
 
   root /bedrock/web;
   index index.php;

--- a/docker/web/403.html
+++ b/docker/web/403.html
@@ -57,7 +57,7 @@
 
       <h1>You are not authorised to view this page.</h1>
       <p>If you feel that you have reached this page in error, please email
-        <a href="mailto:intranet-support@digital.justice.gov.uk">intrante-support@digital.justice.gov.uk</a></li>.
+        <a href="mailto:intranet-support@digital.justice.gov.uk">intranet-support@digital.justice.gov.uk</a></li>.
       </p>
   </div>
   <script>

--- a/docker/web/403.html
+++ b/docker/web/403.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>You are not authorised to view this page | Ministry of Justice</title>
+  <link rel="stylesheet" href="http://alphagov.github.io/govuk_template/assets/stylesheets/fonts.css?0.22.3">
+  <style>
+    html {
+      font-size: 62.5%;
+    }
+    body {
+      padding:0;
+      margin:0;
+      font-family: "nta", Arial, sans-serif;
+      font-size: 1.6em;
+    }
+    .wrapper {
+      width: 1024px;
+      margin: 0 auto;
+    }
+    .header {
+      padding: 40px 20px 10px 20px;
+      background: #000000;
+      color: #ffffff;
+      overflow:hidden;
+      font-size: 1.4em;
+    }
+    .header img {
+      display:inline-block;
+      vertical-align: bottom;
+      width: 40px;
+      padding-left: 10px;
+      border-left: 2px solid #ffffff;
+      margin-right: 10px;
+    }
+    h1 {
+      font-size: 2.6em;
+    }
+    a {
+      color: #005ea5;
+      text-decoration: none;
+    }
+
+    a:hover {
+      color: #2e8aca;
+      text-decoration: underline;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="wrapper">
+      <img src="http://alphagov.github.io/govuk_template/assets/stylesheets/images/gov.uk_logotype_crown.png?0.22.3" alt="Ministry of Justice Logo">Ministry of Justice
+    </div>
+  </div>
+  <div class="wrapper">
+
+      <h1>You are not authorised to view this page.</h1>
+      <p>If you feel that you have reached this page in error, please email
+        <a href="mailto:intranet-support@digital.justice.gov.uk">intrante-support@digital.justice.gov.uk</a></li>.
+      </p>
+  </div>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-59532760-6', 'auto');
+    ga('send', 'pageview');
+  </script>
+</body>
+</html>

--- a/docker/web/403.html
+++ b/docker/web/403.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-P545JM');</script>
   <meta charset="UTF-8">
   <title>You are not authorised to view this page | Ministry of Justice</title>
   <link rel="stylesheet" href="http://alphagov.github.io/govuk_template/assets/stylesheets/fonts.css?0.22.3">
@@ -48,6 +53,7 @@
   </style>
 </head>
 <body>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-P545JM" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <div class="header">
     <div class="wrapper">
       <img src="http://alphagov.github.io/govuk_template/assets/stylesheets/images/gov.uk_logotype_crown.png?0.22.3" alt="Ministry of Justice Logo">Ministry of Justice
@@ -60,14 +66,5 @@
         <a href="mailto:intranet-support@digital.justice.gov.uk">intranet-support@digital.justice.gov.uk</a></li>.
       </p>
   </div>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-59532760-6', 'auto');
-    ga('send', 'pageview');
-  </script>
 </body>
 </html>


### PR DESCRIPTION
The replaces the default, and very uninformative, nginx 403 error page
with something that gives the support email. This will ensure that users
on yet-to-be whitelisted IPs will know how to get in touch to gain
access.