### PR TITLE
Ensure the informative 403 page always shows

### DIFF
--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -12,6 +12,9 @@ fastcgi_cache_key "$real_scheme$request_method$host$request_uri";
 server {
   listen 80 default_server;
   error_page 403 /403.html;
+  location /403.html {
+    allow all;
+  }
 
   root /bedrock/web;
   index index.php;


### PR DESCRIPTION
The new 403 error page was refusing to show when the site was deployed
via pipline. This was because that the page, itself, was falling under
whitelist control; the server fallback was to show the standard nginx
403 page.  This fixes that by ensuring that `/403.html` is accessible to
all.