### PR TITLE
Redirect all requests for /wp-admin correctly

### DIFF
--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -35,8 +35,11 @@ server {
     rewrite ^/wp-content/uploads/(.*)$ /app/uploads/$1 permanent;
   }
 
-  location /wp-admin {
-    rewrite ^/wp-admin(.*)$ /wp/wp-admin$1 permanent;
+  # Without the prefix matching (`^~`) this does not reliably match paths with
+  # filenames. `location /wp-admin {...` will match `\wp-admin`, but not
+  # `\wp-admin\post-new.php`, for example.
+  location ^~ /wp-admin {
+    rewrite /(.*)$ /wp/$1 permanent;
   }
 
   set $skip_cache 0;


### PR DESCRIPTION
For reasons that are not clear, `location /wp-admin {...` is refusing to
match paths with filenames.  This means that login paths like
`/wp-admin/post-new.php?post_type=post` do not redirect correctly with
the original configuration.  Adding an explicit prefix-matching
operator (`location ^~ /wp-admin {...` and contextualising the rewrite
rule to the block (`rewrite_rule ^/wp-admin...` -> `rewrite_rule
^/(.*)...`) fixes this problem.