### PR TITLE
Make images display on www.intranet.justice.gov.uk

### DIFF
--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -35,9 +35,9 @@ server {
     rewrite ^/wp-content/uploads/(.*)$ /app/uploads/$1 permanent;
   }
 
-  # Without the prefix matching (`^~`) this does not reliably match paths with
-  # filenames. `location /wp-admin {...` will match `\wp-admin`, but not
-  # `\wp-admin\post-new.php`, for example.
+# Without the prefix matching (`^~`) this does not reliably match paths with
+# filenames. `location /wp-admin {...` will match `\wp-admin`, but not
+# `\wp-admin\post-new.php`, for example.
   location ^~ /wp-admin {
     rewrite /(.*)$ /wp/$1 permanent;
   }
@@ -61,6 +61,40 @@ server {
   }
 
   location / {
+    # Stopgap solution take to ensure that images work from https://www.intranet.justice.gov.uk.
+    # Only for use during changeover 8-Sept-2017
+    # Taken from https://enable-cors.org/server_nginx.html
+    # TODO: Review and make more restrictive ASAP.
+    if ($request_method = 'OPTIONS') {
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+      add_header 'Access-Control-Allow-Headers'
+        'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+      add_header 'Access-Control-Max-Age' 1728000;
+      add_header 'Content-Type' 'text/plain; charset=utf-8';
+      add_header 'Content-Length' 0;
+      return 204;
+    }
+
+    if ($request_method = 'POST') {
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+      add_header 'Access-Control-Allow-Headers'
+        'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+      add_header 'Access-Control-Expose-Headers'
+        'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+    }
+
+    if ($request_method = 'GET') {
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+      add_header 'Access-Control-Allow-Headers'
+        'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+      add_header 'Access-Control-Expose-Headers'
+        'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Content-Range,Range';
+    }
+    # End of CORS stopgap solution
+
     try_files $uri $uri/ /index.php?$args;
   }
 


### PR DESCRIPTION
The images are failing a CORS preflight, so I've added a very permissive
CORS config to get them working for the time being.  We'll review and
tighten this up early next week.