### PR TITLE
Fix the broken js images issue in the simplest way

### DIFF
--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -9,6 +9,12 @@ fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=pub01:100m inactive
 fastcgi_cache_use_stale updating error timeout invalid_header http_500;
 fastcgi_cache_key "$real_scheme$request_method$host$request_uri";
 
+# Simple workaround for images broked by missing CORS headers.
+server {
+    server_name www.intranet.justice.gov.uk;
+    return 301 $scheme://intranet.justice.gov.uk$request_uri;
+}
+
 server {
   listen 80 default_server;
   error_page 403 /403.html;


### PR DESCRIPTION
CORS breaks images when a user views the site on
www.intranet.justice.gov.uk.  This is the simplest possible fix for the
problem–far less invovled, and far more secure, than a complex CORS
config.