### PR TITLE
Make logs searchable; Enable fpm slow log

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /
 # 2.1.x version of phantom.
 RUN apt-get update && apt-get install -y ruby ruby-dev phantomjs
 RUN gem install sass
+RUN ln -sf /dev/stdout /var/log/fpm.slow.log
 
 # Run ./build.sh as part of the build process IFF we are running in production
 # mode (set in `docker-compose.yml`), otherwise defer until runtime

--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -9,6 +9,17 @@ fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=pub01:100m inactive
 fastcgi_cache_use_stale updating error timeout invalid_header http_500;
 fastcgi_cache_key "$real_scheme$request_method$host$request_uri";
 
+# Make the logs easier to search in cloudwatch
+log_format json_combined escape=json '{ "time_local": "$time_iso8601", '
+ '"remote_addr": "$remote_addr", '
+ '"remote_user": "$remote_user", '
+ '"request": "$request", '
+ '"status": "$status", '
+ '"body_bytes_sent": "$body_bytes_sent", '
+ '"request_time": "$request_time", '
+ '"http_referrer": "$http_referer", '
+ '"http_user_agent": "$http_user_agent" }';
+
 # Simple workaround for images broked by missing CORS headers.
 server {
     server_name www.intranet.justice.gov.uk;
@@ -21,6 +32,8 @@ server {
   location /403.html {
     allow all;
   }
+
+  access_log /var/log/nginx/access.log json_combined;
 
   root /bedrock/web;
   index index.php;

--- a/docker/etc/php/7.1/fpm/pool.d/pool.conf
+++ b/docker/etc/php/7.1/fpm/pool.d/pool.conf
@@ -229,7 +229,7 @@ pm.max_requests = 1500
 ;       anything, but it may not be a good idea to use the .php extension or it
 ;       may conflict with a real PHP file.
 ; Default Value: not set
-;pm.status_path = /status
+; pm.status_path = /status
 
 ; The ping URI to call the monitoring page of FPM. If this value is not set, no
 ; URI will be recognized as a ping page. This could be used to test from outside
@@ -250,7 +250,7 @@ pm.max_requests = 1500
 
 ; The access log file
 ; Default: not set
-;access.log = log/$pool.access.log
+; access.log = /var/log/$pool.access.log
 
 ; The access log format.
 ; The following syntax is allowed
@@ -314,20 +314,20 @@ pm.max_requests = 1500
 ; The log file for slow requests
 ; Default Value: not set
 ; Note: slowlog is mandatory if request_slowlog_timeout is set
-;slowlog = log/$pool.log.slow
+slowlog = /var/log/fpm.slow.log
 
 ; The timeout for serving a single request after which a PHP backtrace will be
 ; dumped to the 'slowlog' file. A value of '0s' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-;request_slowlog_timeout = 0
+request_slowlog_timeout = 1s
 
 ; The timeout for serving a single request after which the worker process will
 ; be killed. This option should be used when the 'max_execution_time' ini option
 ; does not stop script execution for some reason. A value of '0' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-;request_terminate_timeout = 0
+request_terminate_timeout = 5s
 
 ; Set open file descriptor rlimit.
 ; Default Value: system defined value

--- a/docker/etc/php/7.1/fpm/pool.d/pool.conf
+++ b/docker/etc/php/7.1/fpm/pool.d/pool.conf
@@ -327,7 +327,7 @@ request_slowlog_timeout = 1s
 ; does not stop script execution for some reason. A value of '0' means 'off'.
 ; Available units: s(econds)(default), m(inutes), h(ours), or d(ays)
 ; Default Value: 0
-request_terminate_timeout = 5s
+;request_terminate_timeout = 5s
 
 ; Set open file descriptor rlimit.
 ; Default Value: system defined value


### PR DESCRIPTION
It appears cloudwatch has very limited search capabilities for non-json
formatted logs–simple wildcards only. JSON formatted logs, however,
have a much more sophsiticated search DSL.  This should make it much
easier to find things in the logs.

I have also enabled the fpm slow log in an effort to track down the
cause of the remaining 504s and slow event feed load times.  The setting
I've chosen are aggressive–they may need review after a few days.  Also,
it is worth noting that triggering this log locally is tricky.  As a
result, I do not know its format, so it may be diffcult to search on
cloudwatch. There does not seem to be a simple way to configure it to
output json.  I will experiment with doing so if it becomes necessary.