### PR TITLE
Ensure caching meets expectations of end users

### DIFF
--- a/wp-content/themes/mojintranet/inc/cache.php
+++ b/wp-content/themes/mojintranet/inc/cache.php
@@ -4,8 +4,8 @@
   }
 
   function dw_clear_headers() {
-    $cache_timeout = 90;
-    
+    $cache_timeout = 60;
+
     $headers['Cache-Control'] = 'public, max-age='.$cache_timeout;
     $headers['Expires'] = gmdate('D, d M Y H:i:s \G\M\T', time() + ($cache_timeout?:60));
 

--- a/wp-content/themes/mojintranet/inc/headers.php
+++ b/wp-content/themes/mojintranet/inc/headers.php
@@ -12,5 +12,5 @@ if (!current_user_can('edit_posts') && $cache_timeout > 0) {
 else {
   header('Cache-Control: private, max-age=0, no-cache');
   header("Pragma: no-cache");
-  header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', time() - 60));
+  header('Expires: ' . gmdate('D, d M Y H:i:s \G\M\T', time() - $cache_timeout));
 }

--- a/wp-content/themes/mojintranet/page_about_us.php
+++ b/wp-content/themes/mojintranet/page_about_us.php
@@ -27,7 +27,6 @@ class Page_about_us extends MVC_controller {
     return array(
       'page' => 'pages/about_us/main',
       'template_class' => 'about-us',
-      'cache_timeout' => 60 * 15, /* 15 minutes */
       'page_data' => array(
         'enable_agency_about_us' => $this->enable_agency_about_us ? 1 : 0,
         'title' => $title,

--- a/wp-content/themes/mojintranet/page_blog.php
+++ b/wp-content/themes/mojintranet/page_blog.php
@@ -23,7 +23,6 @@ class Page_blog extends MVC_controller {
       'page' => 'pages/blog_landing/main',
       'template_class' => 'blog-landing',
       'breadcrumbs' => true,
-      'cache_timeout' => 60 * 60 * 24, /* 1 day */
       'page_data' => array(
         'top_slug' => htmlspecialchars($top_slug)
       )

--- a/wp-content/themes/mojintranet/page_campaign_content.php
+++ b/wp-content/themes/mojintranet/page_campaign_content.php
@@ -62,7 +62,6 @@ class Page_campaign_content extends MVC_controller {
     return array(
       'page' => 'pages/campaign_content/main',
       'template_class' => 'campaign-content',
-      'cache_timeout' => 60 * 60, /* 1 hour */
       'page_data' => array(
         'id' => $this->post_ID,
         'title' => get_the_title(),

--- a/wp-content/themes/mojintranet/page_campaign_landing.php
+++ b/wp-content/themes/mojintranet/page_campaign_landing.php
@@ -30,7 +30,6 @@ class Page_campaign_landing extends MVC_controller {
     return [
       'page' => 'pages/campaign_landing/main',
       'template_class' => 'campaign-landing',
-      'cache_timeout' => 60 * 60 * 24 /* 1 day */,
       'page_data' => [
         'id' => $this->post_id,
         'title' => get_the_title(),

--- a/wp-content/themes/mojintranet/page_error.php
+++ b/wp-content/themes/mojintranet/page_error.php
@@ -21,9 +21,9 @@ class Page_error extends MVC_controller {
   }
   private function get_data($view) {
     return array(
+      'cache_timeout' => 0, /* Never cache error pages */
       'page' => 'pages/error/' . $view,
-      'template_class' => 'error',
-      //'cache_timeout' => 60 * 60 * 24 /* 1 day */
+      'template_class' => 'error'
     );
   }
 }

--- a/wp-content/themes/mojintranet/page_events.php
+++ b/wp-content/themes/mojintranet/page_events.php
@@ -17,7 +17,6 @@ class Page_events extends MVC_controller {
       'page' => 'pages/events_landing/main',
       'template_class' => 'events-landing',
       'breadcrumbs' => true,
-      'cache_timeout' => 60 * 60 * 24, /* 1 day */
       'page_data' => [
         'page_base_url' => rtrim(get_permalink($this->post_id), '/'),
       ]

--- a/wp-content/themes/mojintranet/page_generic.php
+++ b/wp-content/themes/mojintranet/page_generic.php
@@ -59,7 +59,6 @@ function get_data(){
     return array(
       'page' => 'pages/generic/main',
       'template_class' => 'generic',
-      'cache_timeout' => 60 * 60, /* 1 hour */
       'page_data' => array(
         'id' => $this->post_ID,
         'title' => get_the_title(),

--- a/wp-content/themes/mojintranet/page_guidance_and_support.php
+++ b/wp-content/themes/mojintranet/page_guidance_and_support.php
@@ -5,7 +5,7 @@
  *
  * Template name: Tabs
  */
- 
+
 class Page_guidance_and_support extends MVC_controller {
   function main(){
     $this->model('my_moj');
@@ -55,7 +55,6 @@ class Page_guidance_and_support extends MVC_controller {
     return array(
       'page' => 'pages/guidance_and_support_content/main',
       'template_class' => 'guidance-and-support-content',
-      'cache_timeout' => 60 * 60, /* 60 minutes */
       'page_data' => array(
         'id' => $this->post_ID,
         'tablist_classes' => implode(' ', $tablist_classes),

--- a/wp-content/themes/mojintranet/page_guidance_and_support_index.php
+++ b/wp-content/themes/mojintranet/page_guidance_and_support_index.php
@@ -18,7 +18,6 @@ class Page_guidance_and_support_index extends MVC_controller {
     return array(
       'page' => 'pages/guidance_and_support/main',
       'template_class' => 'guidance-and-support-index',
-      'cache_timeout' => 60 * 30, /* 30 minutes */
       'page_data' => array(
         'title' => get_the_title(),
         'excerpt' => $post->post_excerpt // Not using get_the_excerpt() to prevent auto-generated excerpts being displayed

--- a/wp-content/themes/mojintranet/page_home.php
+++ b/wp-content/themes/mojintranet/page_home.php
@@ -3,7 +3,7 @@
 /**
  * Template name: Home page
  */
- 
+
 class Page_home extends MVC_controller {
   function __construct($param_string, $post_id) {
     parent::__construct($param_string, $post_id);
@@ -20,7 +20,6 @@ class Page_home extends MVC_controller {
     return [
       'page' => 'pages/homepage/main',
       'template_class' => 'home',
-      'cache_timeout' => 60 * 60 * 24 /* 1 day */,
       'no_breadcrumbs' => true,
       'page_data' => [
         'news_widget' => [

--- a/wp-content/themes/mojintranet/page_media_grid.php
+++ b/wp-content/themes/mojintranet/page_media_grid.php
@@ -57,7 +57,6 @@ class Page_media_grid extends MVC_controller
       return array(
       'page' => 'pages/media_grid/main',
       'template_class' => 'media-grid',
-      'cache_timeout' => 60 * 60, /* 1 hour */
       'page_data' => array(
         'id' => $this->post_ID,
         'title' => get_the_title(),

--- a/wp-content/themes/mojintranet/page_news.php
+++ b/wp-content/themes/mojintranet/page_news.php
@@ -23,7 +23,6 @@ class Page_news extends MVC_controller {
       'page' => 'pages/news_landing/main',
       'template_class' => 'news-landing',
       'breadcrumbs' => true,
-      'cache_timeout' => 60 * 60 * 24, /* 1 day */
       'page_data' => [
         'page_base_url' => rtrim(get_permalink($this->post_id), '/'),
         'news_categories' => htmlspecialchars(json_encode($this->model->taxonomy->get([

--- a/wp-content/themes/mojintranet/page_regional_events.php
+++ b/wp-content/themes/mojintranet/page_regional_events.php
@@ -18,7 +18,6 @@ class Page_regional_events extends MVC_controller {
       'page' => 'pages/regional_events_landing/main',
       'template_class' => 'regional-events-landing',
       'breadcrumbs' => true,
-      'cache_timeout' => 60 * 60 * 24, /* 1 day */
       'page_data' => [
         'id' => $this->post_id,
         'title' => get_the_title(),

--- a/wp-content/themes/mojintranet/page_regional_landing.php
+++ b/wp-content/themes/mojintranet/page_regional_landing.php
@@ -34,7 +34,6 @@ class Page_regional_landing extends MVC_controller {
     return [
       'page' => 'pages/regional_landing/main',
       'template_class' => 'regional-landing',
-      'cache_timeout' => 60 * 60, /* 1 hour */
       'page_data' => [
         'id' => $this->post_ID,
         'title' => get_the_title(),

--- a/wp-content/themes/mojintranet/page_regional_news.php
+++ b/wp-content/themes/mojintranet/page_regional_news.php
@@ -19,7 +19,6 @@ class Page_regional_news extends MVC_controller {
     return [
       'page' => 'pages/regional_updates_landing/main',
       'template_class' => 'regional-updates-landing',
-      'cache_timeout' => 60 * 60, /* 1 hour */
       'page_data' => [
         'id' => $this->post_id,
         'title' => get_the_title(),

--- a/wp-content/themes/mojintranet/page_search_results.php
+++ b/wp-content/themes/mojintranet/page_search_results.php
@@ -24,7 +24,6 @@ class Page_search_results extends MVC_controller {
     return array(
       'page' => 'pages/search_results/main',
       'template_class' => 'search-results',
-      'cache_timeout' => 60 * 60 * 24, /* 1 day */
       'page_data' => array(
         'top_slug' => htmlspecialchars($top_slug),
         'dw_tag' => Taggr::get_current()

--- a/wp-content/themes/mojintranet/single-event.php
+++ b/wp-content/themes/mojintranet/single-event.php
@@ -29,7 +29,6 @@ class Single_event extends MVC_controller {
     return array(
       'page' => 'pages/event_single/main',
       'template_class' => 'single-event',
-      'cache_timeout' => 60 * 30, /* 30 minutes */
       'page_data' => array(
         'id' => $this_id,
         'author' => get_the_author(),

--- a/wp-content/themes/mojintranet/single-news.php
+++ b/wp-content/themes/mojintranet/single-news.php
@@ -33,7 +33,6 @@ class Single_news extends MVC_controller {
       return array(
       'page' => 'pages/news_single/main',
       'template_class' => 'single-news',
-      'cache_timeout' => 60 * 30, /* 30 minutes */
       'page_data' => array(
         'id' => $this_id,
         'thumbnail' => $thumbnail[0],

--- a/wp-content/themes/mojintranet/single-post.php
+++ b/wp-content/themes/mojintranet/single-post.php
@@ -46,7 +46,6 @@ class Single_post extends MVC_controller {
     return [
       'page' => 'pages/blog_post/main',
       'template_class' => 'blog-post',
-      'cache_timeout' => 60 * 30, /* 30 minutes */
       'page_data' => [
         'id' => $this_id,
         'thumbnail' => $thumbnail[0],

--- a/wp-content/themes/mojintranet/single-regional_news.php
+++ b/wp-content/themes/mojintranet/single-regional_news.php
@@ -25,7 +25,6 @@ class Single_regional_news extends MVC_controller {
     return array(
       'page' => 'pages/regional_news_single/main',
       'template_class' => 'single-news',
-      'cache_timeout' => 60 * 30, /* 30 minutes */
       'page_data' => array(
         'id' => $this_id,
         'thumbnail' => $thumbnail[0],

--- a/wp-content/themes/mojintranet/single-webchat.php
+++ b/wp-content/themes/mojintranet/single-webchat.php
@@ -28,7 +28,6 @@ class Single_webchat extends MVC_controller {
     return array(
       'page' => 'pages/webchat_single/main',
       'template_class' => 'webchat-single',
-      'cache_timeout' => 60 * 30, /* 30 minutes */
       'page_data' => array(
         'id' => $this->post_ID,
         'title' => get_the_title(),

--- a/wp-content/themes/mojintranet/user.php
+++ b/wp-content/themes/mojintranet/user.php
@@ -109,7 +109,6 @@ class User extends MVC_controller {
             $this->view('layouts/default', [
               'page' => 'pages/user/activate/expired/main',
               'template_class' => 'user-activate-expired',
-              'cache_timeout' => 60 * 30, /* 30 minutes */
               'no_breadcrumbs' => true,
               'page_data' => [
               ]


### PR DESCRIPTION
The Content team expect that newly published articles will appear on the
site within 60 seconds of publication.  Due to the aggressive nature of
browser caching, and our varying `cache_timeout` settings, this was
frequently not the case.  This change ensures that all caching will be
done for 60 seconds.

I started by making all of the `cache_timeout` settings equal to 60,
then I realised this could be DRY'd out by simply removing them and
setting the default timeout to 60 seconds.  I replaced the
`cache_timeout` key for error pages, only-set to zero seconds, this
continues to prevent the error pages from caching by sending max-age=0;

This *may* cause performance problem on production, so we should monitor
server performance for some time after it is released.