### PR TITLE
Make debugging of like functionality simpler

### DIFF
--- a/wp-content/themes/mojintranet/models/likes.php
+++ b/wp-content/themes/mojintranet/models/likes.php
@@ -4,40 +4,21 @@ class Likes_model extends MVC_model {
   public static $meta_key = 'dw_inc_likes';
 
   public function read($content_type, $post_id) {
-    if ($this->is_valid_content_type($content_type)) {
-      return array(
-        'count' => (int) $this->get_like_count($content_type, $post_id)
-      );
-    } else {
-      return false;
-    }
+    return array(
+      'count' => (int) $this->get_like_count($content_type, $post_id)
+    );
   }
 
   public function update($content_type,$post_id) {
-    if($this->is_valid_content_type($content_type)) {
-      $count = $this->get_like_count($content_type,$post_id) + 1;
-      $update_status = call_user_func("update_" . $content_type . "_meta", $post_id, $this::$meta_key, $count );
-      return array(
-        "count" => (int) $count,
-        "update_status" => $update_status
-      );
-    } else {
-      return array(
-        "update_status" => false
-      );
-    }
+    $count = $this->get_like_count($content_type,$post_id) + 1;
+    $update_status = call_user_func("update_" . $content_type . "_meta", $post_id, $this::$meta_key, $count);
+    return array(
+      "count" => (int) $count,
+      "update_status" => $update_status
+    );
   }
 
   private function get_like_count($content_type, $post_id) {
-    return call_user_func("get_" . $content_type . "_meta", $post_id, $this::$meta_key, true )?:0;
-  }
-
-  private function is_valid_content_type($content_type) {
-    $supported_content_types = array($content_type,'comment');
-    if(in_array($content_type, $supported_content_types)) {
-      return true;
-    } else {
-      return false;
-    }
+    return call_user_func("get_" . $content_type . "_meta", $post_id, $this::$meta_key, true)?:0;
   }
 }


### PR DESCRIPTION
This method *always* return true regardless of input and was therefore.
Removing it shortens `like.php` and makes it more efficient and easier
to maintain.