### PR TITLE
Added breadcrumb plugin NavXT for use in the new Clarity theme.

### DIFF
--- a/docker/moj.json
+++ b/docker/moj.json
@@ -10,6 +10,7 @@
     {"type":"vcs", "no-api": true, "url":"https://github.com/ministryofjustice/intranet.git"}
   ],
   "require": {
+    "wpackagist-plugin/breadcrumb-navxt":"5.7.1",
     "wpackagist-plugin/cms-tree-page-view":"1.3.4",
     "wpackagist-plugin/co-authors-plus":"3.2.2",
     "wpackagist-plugin/recently-edited-content-widget":"0.3.2",


### PR DESCRIPTION
@tatyree could you review? Breadcrumb functionality doesn't come out of the box with Wordpress. A decision had to be made between writing an in-house custom breadcrumb plugin for the new Clarity theme or using a third party plugin. After consultation with TP and Vinh, this looks to be the more favoured approach. Installing this plugin now won't affect the current site, but it will be required for any new Clarity templates we launch.