### PR TITLE
Added CSS logic to only display custom JO blog menu button. 

### DIFF
--- a/wp-content/themes/mojintranet/assets/css/src/modules/_main_nav.scss
+++ b/wp-content/themes/mojintranet/assets/css/src/modules/_main_nav.scss
@@ -12,6 +12,20 @@
     }
   }
 
+  .jo-nav-blog {
+    display: none;
+
+    html[data-agency="judicial-office"] & {
+      display: block;
+    }
+  }
+
+  .main-nav-blog {
+    html[data-agency="judicial-office"] & {
+      display: none;
+    }
+  }
+
   .main-menu-list {
     @include clearfix;
     display: -webkit-box;


### PR DESCRIPTION
I've done this in keeping with how the old site's approached to menu buttons. A CSS class hides the button in question from every agency except the one you specify - in this case a custom Blog menu item for the JO that allows for the custom blog link they wanted. Included in this commit is hiding the default blog menu button. Without this, you would have two blog buttons in the menu when visiting as a JO user.