### PR TITLE
Removed Blog posts from appearing on the JO homepage.

### DIFF
--- a/wp-content/themes/mojintranet/assets/css/src/modules/_posts.scss
+++ b/wp-content/themes/mojintranet/assets/css/src/modules/_posts.scss
@@ -3,6 +3,10 @@
     display: none;
   }
 
+  html[data-agency="judicial-office"] & {
+    display: none;
+  }
+
   .posts-heading {
     @extend %large-heading;
     border-bottom: 1px solid #6f777b;


### PR DESCRIPTION
The .post-widget class controls the display of blog posts on an agency's homepage. This change set's the class to not display when viewed by a Judicial Office user. 