### PR TITLE
Remove image size restrictions

### DIFF
--- a/wp-content/themes/mojintranet/inc/images.php
+++ b/wp-content/themes/mojintranet/inc/images.php
@@ -15,10 +15,29 @@ add_action( 'admin_init', 'dw_force_image_dimensions' );
 
 function dw_force_image_dimensions() {
   if(!current_user_can( 'administrator')) {
-    add_filter( 'wp_handle_upload_prefilter' );
+    add_filter( 'wp_handle_upload_prefilter', 'dw_block_small_images_upload' );
   }
 }
 
+function dw_block_small_images_upload( $file ) {
+  // Mime type with dimensions, check to exit earlier
+  $mimes = array( 'image/jpeg', 'image/png', 'image/gif' );
+
+  if( !in_array( $file['type'], $mimes ) ) {
+    return $file;
+  }
+
+  $img = getimagesize( $file['tmp_name'] );
+  $minimum = array( 'width' => 1, 'height' => 1 );
+
+  if ( $img[0] < $minimum['width'] ) {
+    $file['error'] = 'Image too small. Minimum width is ' . $minimum['width'] . 'px. Uploaded image width is ' . $img[0] . 'px';
+  } elseif ( $img[1] < $minimum['height'] ) {
+    $file['error'] = 'Image too small. Minimum height is ' . $minimum['height'] . 'px. Uploaded image height is ' . $img[1] . 'px';
+  }
+
+  return $file;
+}
 function dw_remove_size_attributes($html) {
   $html = preg_replace('/(width|height)="\d*"\s/', "", $html);
   return $html;

--- a/wp-content/themes/mojintranet/inc/images.php
+++ b/wp-content/themes/mojintranet/inc/images.php
@@ -15,28 +15,8 @@ add_action( 'admin_init', 'dw_force_image_dimensions' );
 
 function dw_force_image_dimensions() {
   if(!current_user_can( 'administrator')) {
-    add_filter( 'wp_handle_upload_prefilter', 'dw_block_small_images_upload' );
+    add_filter( 'wp_handle_upload_prefilter' );
   }
-}
-
-function dw_block_small_images_upload( $file ) {
-  // Mime type with dimensions, check to exit earlier
-  $mimes = array( 'image/jpeg', 'image/png', 'image/gif' );
-
-  if( !in_array( $file['type'], $mimes ) ) {
-    return $file;
-  }
-
-  $img = getimagesize( $file['tmp_name'] );
-  $minimum = array( 'width' => 960, 'height' => 640 );
-
-  if ( $img[0] < $minimum['width'] ) {
-    $file['error'] = 'Image too small. Minimum width is ' . $minimum['width'] . 'px. Uploaded image width is ' . $img[0] . 'px';
-  } elseif ( $img[1] < $minimum['height'] ) {
-    $file['error'] = 'Image too small. Minimum height is ' . $minimum['height'] . 'px. Uploaded image height is ' . $img[1] . 'px';
-  }
-
-  return $file;
 }
 
 function dw_remove_size_attributes($html) {


### PR DESCRIPTION
This is causing agency editors a lot of problems. These problems are
having a knock-on effect on the team in that we are getting requests to
upload/manage banners, which the editors should be able to do for
themselves.  Removing these restrictions should solve that problem at
the potential risk of introducing issues with mis-sized images.
However, that is an editorial issue.