### PR TITLE
Ensure clarity assets get build in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docker/bedrock_volume/config
 docker/bedrock_volume/*.json
 docker/bedrock_volume/*.js
 docker/bedrock_volume/*.lock
+docker/bedrock_volume/node_modules
 
 # wordpress specific
 wp-content/uploads/

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -64,9 +64,14 @@ mv vendor/ministryofjustice/intranet/wp-content/themes/mojintranet web/app/theme
 rm -rf vendor/ministryofjustice
 
 # Build theme assets
-npm install -g grunt-cli
+npm install --global grunt-cli
 npm install
 grunt pre_deploy
+cd /bedrock/web/app/themes/intranet-theme-clarity
+npm install --global gulp-cli
+npm install
+gulp build
+cd /bedrock
 
 # Keep the container size down
 rm *.json


### PR DESCRIPTION
This appears to be happening on the fly and automagically in dev, but
not at all in production.  This *should* make the behaviour consistent
between the two.