### PR TITLE
Removed copy re. 3 hour limit on commenting links

### DIFF
--- a/wp-content/themes/mojintranet/views/email/activate_account.php
+++ b/wp-content/themes/mojintranet/views/email/activate_account.php
@@ -37,7 +37,6 @@
               href="<?=$activation_url?>">Begin commenting</a>
           </p>
           <p style="padding: 5px 0; font-size: 19px; font-family: Arial, sans-serif;">This will take you back to the intranet page you were on where you can begin commenting.</p>
-          <p style="padding: 5px 0; font-size: 19px; font-family: Arial, sans-serif;">For security reasons, this link will be active for 3 hours only. </p>
           <h2>Any problems?</h2>
           <p style="padding: 5px 0; font-size: 19px; font-family: Arial, sans-serif;">If this link has expired, you’ll need to fill in your details again to get another link. If you don’t want to comment on the intranet, ignore this email.</p>
           <p style="padding: 5px 0; font-size: 19px; font-family: Arial, sans-serif;">The Intranet Team</p>

--- a/wp-content/themes/mojintranet/views/pages/user/activate/request_activation_link_confirmation.php
+++ b/wp-content/themes/mojintranet/views/pages/user/activate/request_activation_link_confirmation.php
@@ -8,7 +8,6 @@
 
         <p>We're sending an email to <span class="recipient-email"></span>. This can take up to 5 minutes.</p>
         <p>Open the email and click on the link. This will take you back to the intranet where you can start commenting.</p>
-        <p>The link is active for 3 hours so you must click on it within that time.</p>
 
         <h2>Any problems?</h2>
 


### PR DESCRIPTION
The links have been observed to be active for more than three hours. Given that access is whitelisted, and the commentor is required to have a `justice.gov.uk` address, the security risk that arises because timeout is **not** functioning is very low.  As per our pre-Christmas planning, I am
removing the copy concerning the expiry from the app.