### PR TITLE
Replace a missing curly brace

### DIFF
--- a/docker/moj.json
+++ b/docker/moj.json
@@ -27,4 +27,4 @@
     "ministryofjustice/intranet":"dev-master",
     "wpackagist-theme/twentyseventeen":"1.3"
   }
-
+}


### PR DESCRIPTION
I knew about this, but forgot to replace it when I made the previous
merge.