### PR TITLE
Change the branch of clarity used

### DIFF
--- a/docker/moj.json
+++ b/docker/moj.json
@@ -23,7 +23,7 @@
     "ministryofjustice/dw-document-revisions":"dev-update-composer-json",
     "ministryofjustice/dw-live-drafts":"dev-update-composer-json",
     "ministryofjustice/dw-markdown":"dev-update-composer-json",
-    "ministryofjustice/intranet-theme-clarity":"dev-update-composer-json",
+    "ministryofjustice/intranet-theme-clarity":"dev-master",
     "ministryofjustice/intranet":"dev-master",
     "wpackagist-theme/twentyseventeen":"1.3"
   }


### PR DESCRIPTION
This is needed because the clarity theme and the WP update branch are
diverging.  Needs to be addressed before it becomes a problem.