### PR TITLE
Install Ollie's s3 rewriting plugin

### DIFF
--- a/docker/moj.json
+++ b/docker/moj.json
@@ -25,6 +25,7 @@
     "ministryofjustice/dw-markdown":"dev-update-composer-json",
     "ministryofjustice/intranet-theme-clarity":"dev-master",
     "ministryofjustice/intranet":"dev-master",
+    "ministryofjustice/wp-rewrite-media-to-s3": "*",
     "wpackagist-theme/twentyseventeen":"1.3"
   }
 }


### PR DESCRIPTION
This got missed on the AWS switchover and is required to ensure images
for non-editorial users get served directly from the S3 bucket and not
from the WP instance, itself.