### PR TITLE
installed latest version of relevanssi

### DIFF
--- a/docker/moj.json
+++ b/docker/moj.json
@@ -16,7 +16,7 @@
     "wpackagist-plugin/recently-edited-content-widget":"0.3.2",
     "wpackagist-plugin/regenerate-thumbnails":"2.2.6",
     "wpackagist-plugin/upload-url-path-enabler":"1.0.4",
-    "wpackagist-plugin/relevanssi": "4.0.3",
+    "relevanssi/relevanssi-premium":"2.0.3.1",
     "acf/advanced-custom-fields-pro":"5.4.4",
 
     "ministryofjustice/dw-mvc":"dev-update-composer-json",

--- a/docker/moj.json
+++ b/docker/moj.json
@@ -16,7 +16,7 @@
     "wpackagist-plugin/recently-edited-content-widget":"0.3.2",
     "wpackagist-plugin/regenerate-thumbnails":"2.2.6",
     "wpackagist-plugin/upload-url-path-enabler":"1.0.4",
-    "relevanssi/relevanssi-premium":"1.14.2",
+    "wpackagist-plugin/relevanssi": "4.0.3",
     "acf/advanced-custom-fields-pro":"5.4.4",
 
     "ministryofjustice/dw-mvc":"dev-update-composer-json",


### PR DESCRIPTION
removing the premium version. as it was conflicting with the wordpress core API
updated to the latest free version because we didn't have login details to download the latest premium version.
Latest free version is now working with WP core api