### PR TITLE
Increase fpm children per container

### DIFF
--- a/docker/etc/php/7.1/fpm/pool.d/pool.conf
+++ b/docker/etc/php/7.1/fpm/pool.d/pool.conf
@@ -7,7 +7,7 @@ listen.owner = www-data
 listen.group = www-data
 
 pm = static
-pm.max_children = 20
+pm.max_children = 25
 pm.max_requests = 2000
 
 


### PR DESCRIPTION
Since changing the memory settings, memory utilisation has fallen from
~115% to ~68%.  I'm increasing the number of childern in a effort to
increase performance.