### PR TITLE
Reduce max_children and max_requests

### DIFF
--- a/docker/etc/php/7.1/fpm/pool.d/pool.conf
+++ b/docker/etc/php/7.1/fpm/pool.d/pool.conf
@@ -7,8 +7,8 @@ listen.owner = www-data
 listen.group = www-data
 
 pm = static
-pm.max_children = 25
-pm.max_requests = 2000
+pm.max_children = 20
+pm.max_requests = 1500
 
 
 slowlog = /var/log/fpm.slow.log


### PR DESCRIPTION
I **supect** that the 502 errors we are seeing are the result of a
mismatch between the number of nginx workers and the fpm workers.  I'm
putting the number of fpm workers back down to 20, and reducing their
lifespan (2000 requests to 1500 requests before a worker is replaced)
to see if that stops these errors.