### PR TITLE
Remove the request_terminate_timeout setting

### DIFF
--- a/docker/etc/php/7.1/fpm/pool.d/pool.conf
+++ b/docker/etc/php/7.1/fpm/pool.d/pool.conf
@@ -10,9 +10,7 @@ pm = static
 pm.max_children = 20
 pm.max_requests = 1500
 
-
 slowlog = /var/log/fpm.slow.log
 request_slowlog_timeout = 1s
-request_terminate_timeout = 5s
 
 clear_env = no


### PR DESCRIPTION
I believe this is what is causing the current spate of 502 errors. The documentation
(http://php.net/manual/en/install.fpm.configuration.php) strongly
suggests it overrides `max_execution_time`, which is set to 30 seconds.
If it does, then that would explain why we are seeing so many 502 errors
since I changed the fpm configurations.  It would also explain why it is
nearly impossible to upload a document right now-a typical document is
very, very likely to take more than 5 seconds to upload.