### PR TITLE
Extract dw_agency cookie value and add to cache path

### DIFF
--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -5,9 +5,14 @@ map $http_x_forwarded_proto $real_scheme {
   ''      $scheme;
 }
 
+map $http_cookie $agency_cookie {
+  default "hq";
+  ~^.*(?<key>dw_agency.+\;).*$ $key;
+}
+
 fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=pub01:100m inactive=60m;
 fastcgi_cache_use_stale updating error timeout invalid_header http_500;
-fastcgi_cache_key "$real_scheme$request_method$host$request_uri";
+fastcgi_cache_key "$agency_cookie$real_scheme$request_method$host$request_uri";
 
 # Make the logs easier to search in cloudwatch
 log_format json_combined escape=json '{ "time_local": "$time_iso8601", '

--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -5,14 +5,9 @@ map $http_x_forwarded_proto $real_scheme {
   ''      $scheme;
 }
 
-map $http_cookie $agency_cookie {
-  default "hq";
-  ~^.*(?<key>dw_agency.+\;).*$ $key;
-}
-
 fastcgi_cache_path /var/run/nginx-cache levels=1:2 keys_zone=pub01:100m inactive=60m;
 fastcgi_cache_use_stale updating error timeout invalid_header http_500;
-fastcgi_cache_key "$agency_cookie$real_scheme$request_method$host$request_uri";
+fastcgi_cache_key "$cookie_dw_agency$real_scheme$request_method$host$request_uri";
 
 # Make the logs easier to search in cloudwatch
 log_format json_combined escape=json '{ "time_local": "$time_iso8601", '


### PR DESCRIPTION
When caching is activated and the user changes agency, most of the pages
get stuck with the wrong agency header.  I suspect the problem lies in
the fastcgi cache on nginx because two different users making sequential
requests will both recieve the same, incorrect, header.  This will
always be the header of the first user's request.  As the fastcgi cache
*seems* to be obeying `Cache-Control` headers, and there is no other
intermediate cache (it only caches on the end-users' browsers or nginx
on the local containers), I surmise the wrong information must be
getting stored in the fastcgi cache.  This *should* fix the problem.