### PR TITLE
Update ACF

### DIFF
--- a/docker/moj.json
+++ b/docker/moj.json
@@ -18,7 +18,7 @@
     "wpackagist-plugin/regenerate-thumbnails":"2.2.6",
     "wpackagist-plugin/upload-url-path-enabler":"1.0.4",
     "relevanssi/relevanssi-premium":"2.0.3.1",
-    "acf/advanced-custom-fields-pro":"5.4.4",
+    "acf/advanced-custom-fields-pro":"5.6.10",
     "wpackagist-plugin/wordpress-importer": "0.6.4",
 
     "ministryofjustice/dw-mvc":"dev-master",

--- a/wp-content/themes/mojintranet/inc/redirects.php
+++ b/wp-content/themes/mojintranet/inc/redirects.php
@@ -68,7 +68,9 @@ function dw_rewrite_rules() {
   add_rewrite_rule($regex, $redirect, 'top');
 
 }
-add_action('init', 'dw_redirects');
+if (!is_admin()){
+  add_action('init', 'dw_redirects');
+}
 add_action('init', 'dw_rewrite_rules');
 
 function redirect_404($template) {


### PR DESCRIPTION
Rewrites on the old site have caused issues with WP admin working correctly. We've disabled these rewrites for the admin section. Hopefully in the future we can turn them off on the frontend as well once MVC and mojintranet is retired. 