### PR TITLE
Send all php logs to stdout

### DIFF
--- a/docker/etc/php/7.1/fpm/pool.d/pool.conf
+++ b/docker/etc/php/7.1/fpm/pool.d/pool.conf
@@ -10,7 +10,9 @@ pm = static
 pm.max_children = 20
 pm.max_requests = 1500
 
-slowlog = /var/log/fpm.slow.log
 request_slowlog_timeout = 1s
+slowlog = /proc/self/fd/2
+error_log = /proc/self/fd/2
+access.log = /proc/self/fd/2
 
 clear_env = no


### PR DESCRIPTION
Right now, we only get the nginx logs on the AWS enviroments. This is
causing problems when trying to track down certain issues. These
settings *should* ensure that the PHP logs are sent to CloudWatch as
well. The `access.log` and `error_log` settings were taken from the
official php container and the `slow_log` setting was interpreted.