### PR TITLE
Move error_log to [global]

### DIFF
--- a/docker/etc/php/7.1/fpm/pool.d/pool.conf
+++ b/docker/etc/php/7.1/fpm/pool.d/pool.conf
@@ -1,5 +1,7 @@
-[www]
+[global]
+error_log = /proc/self/fd/2
 
+[www]
 user = www-data
 group = www-data
 listen = /run/php7.0-fpm.sock
@@ -10,9 +12,8 @@ pm = static
 pm.max_children = 20
 pm.max_requests = 1500
 
-request_slowlog_timeout = 1s
+request_slowlog_timeout = 3s
 slowlog = /proc/self/fd/2
-error_log = /proc/self/fd/2
 access.log = /proc/self/fd/2
 
 clear_env = no


### PR DESCRIPTION
This is the section where it is supposed to live.  It breaks the build
if it is in [www].

Also, turned the threshold on slowlog up to 3 seconds as I suspect it
will flood the logs otherwise.