### PR TITLE
Added new markdown plugin, removed old

### DIFF
--- a/docker/moj.json
+++ b/docker/moj.json
@@ -8,7 +8,8 @@
     {"type":"vcs", "no-api": true, "url":"https://github.com/ministryofjustice/dw-markdown.git"},
     {"type":"vcs", "no-api": true, "url":"https://github.com/ministryofjustice/intranet-theme-clarity.git"},
     {"type":"vcs", "no-api": true, "url":"https://github.com/ministryofjustice/intranet.git"},
-    {"type":"vcs", "no-api": true, "url":"https://github.com/ministryofjustice/like-button-for-wordpress.git"}
+    {"type":"vcs", "no-api": true, "url":"https://github.com/ministryofjustice/like-button-for-wordpress.git"},
+    {"type":"vcs", "no-api": true, "url":"https://github.com/ministryofjustice/php-markdown-extra"}
   ],
   "require": {
     "wpackagist-plugin/breadcrumb-navxt":"6.0.4",
@@ -22,13 +23,13 @@
     "wpackagist-plugin/wordpress-importer": "0.6.4",
     "wpackagist-plugin/user-role-editor": "4.42",
     "wpackagist-plugin/query-monitor": "3.0.1",
-    "wpackagist-plugin/wp-markdown": "1.6.1",
 
     "ministryofjustice/dw-mvc":"dev-master",
     "ministryofjustice/dw-document-revisions":"dev-update-composer-json",
     "ministryofjustice/intranet-theme-clarity":"dev-master",
     "ministryofjustice/intranet":"dev-master",
     "ministryofjustice/wp-rewrite-media-to-s3": "*",
-    "ministryofjustice/like-button-for-wordpress":"dev-master"
+    "ministryofjustice/like-button-for-wordpress":"dev-master",
+    "ministryofjustice/php-markdown-extra":"dev-master"
   }
 }


### PR DESCRIPTION
Replaces WP Markdown plugin which was causing editors formatting issues with new markdown plugin that appears to work better. 