### PR TITLE
Roll back breadcrumb version causing PHP notice

### DIFF
--- a/docker/moj.json
+++ b/docker/moj.json
@@ -12,7 +12,7 @@
     {"type":"vcs", "no-api": true, "url":"https://github.com/ministryofjustice/php-markdown-extra.git"}
   ],
   "require": {
-    "wpackagist-plugin/breadcrumb-navxt":"6.1.0",
+    "wpackagist-plugin/breadcrumb-navxt":"6.0.4",
     "wpackagist-plugin/cms-tree-page-view":"1.5",
     "wpackagist-plugin/co-authors-plus":"3.3.0",
     "wpackagist-plugin/recently-edited-content-widget":"0.3.2",


### PR DESCRIPTION
For now we are rolling back to a version without errors.