### PR TITLE
Added additional security headers to nginx config

### DIFF
--- a/docker/etc/nginx/sites-available/server.conf
+++ b/docker/etc/nginx/sites-available/server.conf
@@ -41,6 +41,7 @@ server {
   client_max_body_size 250m;
 
   include /etc/nginx/real_ip.conf;
+  include /etc/nginx/snippets/headers.conf;
 
   if ($http_x_forwarded_proto = "https") {
     set $use_ssl "on";
@@ -54,9 +55,9 @@ server {
     rewrite ^/wp-content/uploads/(.*)$ /app/uploads/$1 permanent;
   }
 
-# Without the prefix matching (`^~`) this does not reliably match paths with
-# filenames. `location /wp-admin {...` will match `\wp-admin`, but not
-# `\wp-admin\post-new.php`, for example.
+  # Without the prefix matching (`^~`) this does not reliably match paths with
+  # filenames. `location /wp-admin {...` will match `\wp-admin`, but not
+  # `\wp-admin\post-new.php`, for example.
   location ^~ /wp-admin {
     rewrite /(.*)$ /wp/$1 permanent;
   }
@@ -83,8 +84,6 @@ server {
     try_files $uri $uri/ /index.php?$args;
   }
 
-  server_tokens off;
-
   include /etc/nginx/whitelists/site-wide.conf;
 
   location ~ /\. {
@@ -97,13 +96,14 @@ server {
 
   location ~ \.php$ {
     include /etc/nginx/php-fpm.conf;
+    include /etc/nginx/snippets/headers.conf;
   }
 
   location = /wp/wp-login.php {
     limit_req zone=flood burst=5 nodelay;
-
     include /etc/nginx/whitelists/wp-login.conf;
     include /etc/nginx/php-fpm.conf;
+    include /etc/nginx/snippets/headers.conf;
   }
 
   location ~ /purge-cache(/.*) {
@@ -115,6 +115,7 @@ server {
   location ~* \.(?:css|js|ico|woff|eot|svg|ttf|otf|png|gif|jpe?g) {
     access_log off;
     add_header Cache-Control public;
+    include /etc/nginx/snippets/headers.conf;
     expires 1d;
   }
 

--- a/docker/etc/nginx/snippets/headers.conf
+++ b/docker/etc/nginx/snippets/headers.conf
@@ -5,4 +5,4 @@ server_tokens off;
 add_header X-Frame-Options DENY;
 add_header X-XSS-Protection "1; mode=block";
 add_header X-Content-Type-Options nosniff;
-add_header Strict-Transport-Security "max-age=120; includeSubDomains" always;
+add_header Strict-Transport-Security "max-age=600; includeSubDomains" always;

--- a/docker/etc/nginx/snippets/headers.conf
+++ b/docker/etc/nginx/snippets/headers.conf
@@ -1,0 +1,8 @@
+# https://www.owasp.org/index.php/List_of_useful_HTTP_headers
+
+server_tokens off;
+
+add_header X-Frame-Options DENY;
+add_header X-XSS-Protection "1; mode=block";
+add_header X-Content-Type-Options nosniff;
+add_header Strict-Transport-Security "max-age=120; includeSubDomains" always;


### PR DESCRIPTION
Missing 'Strict-Transport-Security' header, force browser to communicate with server via HTTPS.