### PR TITLE
Rename repo so composer pulls correct plugin ver.

### DIFF
--- a/docker/moj.json
+++ b/docker/moj.json
@@ -22,7 +22,7 @@
     "acf/advanced-custom-fields-pro":"5.7.10",
     "wpackagist-plugin/wordpress-importer": "0.6.4",
     "wpackagist-plugin/query-monitor": "3.2.2",
-    "ministryofjustice/dw-document-revisions":"dev-update-composer-json",
+    "ministryofjustice/dw-document-revisions":"dev-master",
     "ministryofjustice/intranet":"dev-master",
     "ministryofjustice/wp-rewrite-media-to-s3": "*",
     "ministryofjustice/like-button-for-wordpress":"dev-master",


### PR DESCRIPTION
Someone had been using the wrong repo branch when pulling the plugin.