### PR TITLE
Add homepage crop to banner image

### DIFF
--- a/wp-content/themes/clarity/src/components/c-aside-banner/view.php
+++ b/wp-content/themes/clarity/src/components/c-aside-banner/view.php
@@ -19,7 +19,7 @@ $homepage_sidebar_banner_alt_text = get_field( $agency . '_homepage_sidebar_bann
 
   
   <a href="<?php echo $homepage_sidebar_banner_link; ?>" class="c-aside-banner--link">
-	  <img src="<?php echo $homepage_sidebar_banner_image['sizes']['medium']; ?>" alt="<?php echo $homepage_sidebar_banner_alt_text; ?>">
+	  <img src="<?php echo $homepage_sidebar_banner_image['sizes']['feature-thumbnail']; ?>" alt="<?php echo $homepage_sidebar_banner_alt_text; ?>">
   </a>
 </section>
 <!-- c-aside-banner ends here -->


### PR DESCRIPTION
Editors voted to have the homepage image a rectangle (rather then square), the same as other
homepage images. To be constant, I've gone with the feature-thumbnail size, used across the site for similar images with the same aspect ratio. 