### PR TITLE
Lockdown permissions for editors

### DIFF
--- a/wp-content/themes/clarity/inc/admin/agency_taxonomies/taxonomies/agency.php
+++ b/wp-content/themes/clarity/inc/admin/agency_taxonomies/taxonomies/agency.php
@@ -62,7 +62,7 @@ class Agency extends Taxonomy {
             add_action('admin_menu', array($this, 'add_admin_menu_item'));
         }
 
-        if (current_user_can('assign_agencies_to_posts')) {
+        if ( current_user_can('assign_agencies_to_posts') ) {
             // Show form fields to edit user agency
             // Using priority 9 here to bump it above "More fields" section
             add_action('show_user_profile', array($this, 'edit_user_profile'), 9);
@@ -76,7 +76,7 @@ class Agency extends Taxonomy {
         }
 
         // Add page agency meta box
-        if ( ! current_user_can('assign_agencies_to_posts')) {
+        if ( ! current_user_can('agency_admin') ) {
             // Remove agency meta box
             add_action('admin_menu', array($this, 'remove_agency_meta_box'));
         }
@@ -89,6 +89,10 @@ class Agency extends Taxonomy {
             add_action('save_post', array($this, 'set_agency_terms_on_save_post'));
 
             // Capabilities
+            if ( ! current_user_can('agency_admin')  ) {
+                add_action('map_meta_cap', array($this, 'restrict_edit_post_to_current_agency'), 10, 4);
+            }
+            
 
             if (current_user_can('opt_in_content')) {
                 add_filter('restrict_manage_posts', array($this, 'add_agency_filter'));
@@ -259,6 +263,44 @@ class Agency extends Taxonomy {
         foreach ($this->object_types as $object) {
             remove_meta_box('agencydiv', $object, 'normal');
         }
+    }
+
+
+        /**
+     * Stop users from editing posts that belong to agencies which are not
+     * the current agency context.
+     *
+     * @param $caps
+     * @param $cap
+     * @param $user_id
+     * @param $args
+     *
+     * @return array
+     */
+    public function restrict_edit_post_to_current_agency($caps, $cap, $user_id, $args) {
+        $filter_caps = [
+            'edit_post',
+            'delete_post',
+            'edit_news',
+            'delete_news',
+        ];
+        if (!in_array($cap, $filter_caps) || !isset($args[0])) {
+            // Not relevant, return early.
+            return $caps;
+        }
+        $post_id = $args[0];
+        $post_type = get_post_type($post_id);
+        if (!in_array($post_type, $this->object_types)) {
+            // Not relevant, return early.
+            return $caps;
+        }
+        $owner = Agency_Editor::get_post_agency($post_id);
+        $context = Agency_Context::get_agency_context();
+        if ($owner !== $context) {
+            // User does not have permission to edit this post
+            $caps[] = 'do_not_allow';
+        }
+        return $caps;
     }
 
     public function add_opt_in_out_quick_actions($actions, $post) {


### PR DESCRIPTION
Allow only agency admin's to be able to edit other agencies and
opt-in/out of agency content.