### PR TITLE
Add template so page loads correct breadcrumb

### DIFF
--- a/wp-content/themes/clarity/inc/admin/custom-page-attribute-box.php
+++ b/wp-content/themes/clarity/inc/admin/custom-page-attribute-box.php
@@ -46,14 +46,13 @@ function clarity_custom_page_attribute_box( $post ) {
 	$parent_page    = wp_get_post_parent_id( $post->ID );
 
 
-
-		// current template selected by user
-		$current_template = get_post_meta( $post->ID, '_wp_page_template', true );
+	// current template selected by user
+	$current_template = get_post_meta( $post->ID, '_wp_page_template', true );
 
 		// get full list of templates
-    $templates = get_page_templates($post);
+	$templates = get_page_templates($post);
 
-    $themeselect = '<select id="page_template" name="page_template">';
+	$themeselect = '<select id="page_template" name="page_template">';
 
 		foreach ( $templates as $template_name => $template_filename ) {
 

--- a/wp-content/themes/clarity/page_regional_landing.php
+++ b/wp-content/themes/clarity/page_regional_landing.php
@@ -4,7 +4,7 @@ use MOJ\Intranet\EventsHelper;
 /**
  *
  * Template name: Region landing
- *
+ * Template Post Type: regional_page
  */
 $terms = get_the_terms( get_the_ID(), 'region' );
 
@@ -27,6 +27,10 @@ get_header();
 	<div class="l-primary" role="main">
 
 	  <h1 class="o-title o-title--page"><?php the_title(); ?></h1>
+
+	  <div class="template-container ">
+		<?php get_template_part( 'src/components/c-rich-text-block/view' ); ?>
+	  </div>
 
 		<?php
 		echo '<div id="content">';


### PR DESCRIPTION
The region landing template was not available to editors, meaning that it was not the selected template on the regional landing page and it was defaulting to the default template. 

By using the default template rather than the regional landing template,
there was a knock on effect in that the wrong breadcrumb loaded on the regional landing page. 

This was fixed, also I added a content area to regional template to account for that space being used by editors during the time they have been using the default template rather than the regional one. ..so they now have it on both.