### PR TITLE
Fix and update TotalPoll plugin support

### DIFF
--- a/wp-content/themes/clarity/inc/admin/plugins/polls.php
+++ b/wp-content/themes/clarity/inc/admin/plugins/polls.php
@@ -6,31 +6,23 @@
  */
 
 // Check if plugin is activated
-if ( in_array( 'totalpoll-lite/totalpoll.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) :
-
-	/**
-	 * BUG fix we have to Load Tiny MCE editor as this plugin needs it and throws a JS error without it.
-	 */
-
-	add_action( 'admin_enqueue_scripts', 'load_tinymce' );
-
-	function load_tinymce() {
-		wp_enqueue_script( 'tinymce', 'https://cdnjs.cloudflare.com/ajax/libs/tinymce/4.5.6/tinymce.min.js' );
-	}
+if ( in_array( 'totalpoll-lite/plugin.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ) ) ) :
 
 	/**
 	 * Remove (for editors) options and settings not needed.
 	 */
-	add_action( 'do_meta_boxes', 'remove_poll_meta_boxes_and_tabs' );
+	add_action( 'admin_menu', 'remove_poll_meta_boxes_and_tabs' );
 
 	// Remove everything that an editor doesn't need to see.
 	function remove_poll_meta_boxes_and_tabs() {
 
 		if ( ! current_user_can( 'administrator' ) ) {
-			echo '<style> .settings-tabs, .containables-types li:nth-child(1n+3) { display:none !important } a[data-tp-tab="browse-submissions"] { display:none !important }</style>';
-			echo '<style> .settings-tabs, .settings-item:nth-child(1n+3) { display:none !important }</style>';
-			remove_meta_box( 'postimagediv', 'poll', 'side' );
-			remove_meta_box( 'postexcerpt', 'poll', 'normal' );
+			echo '<style> .totalpoll-page-tabs { display:none !important }</style>';
+			echo '<style> .totalpoll-column-sidebar { display:none !important }</style>';
+			echo '<style> .totalpoll-box-totalsuite { display:none !important }</style>';
+			echo '<style> .totalpoll-pro-badge { display:none !important }</style>';
+			echo '<style> .totalpoll-pro-badge-container { display:none !important }</style>';
+			echo '<style> .totalpoll-overview-item-segment:nth-of-type(2) { display:none !important }</style>';		
 		}
 	}
 
@@ -39,8 +31,13 @@ if ( in_array( 'totalpoll-lite/totalpoll.php', apply_filters( 'active_plugins', 
 
 	function remove_menu_links() {
 		if ( ! current_user_can( 'administrator' ) ) {
-			remove_submenu_page( 'edit.php?post_type=poll', 'tp-about' );
-			remove_submenu_page( 'edit.php?post_type=poll', 'tp-support' );
+			remove_submenu_page( 'edit.php?post_type=poll', 'upgrade-to-pro' );
+			remove_submenu_page( 'edit.php?post_type=poll', 'options' );
+			remove_submenu_page( 'edit.php?post_type=poll', 'extensions' );
+			remove_submenu_page( 'edit.php?post_type=poll', 'templates' );
+			remove_submenu_page( 'edit.php?post_type=poll', 'log' );
+			remove_submenu_page( 'edit.php?post_type=poll', 'insights' );
+			remove_submenu_page( 'edit.php?post_type=poll', 'entries' );
 		}
 	}
 

--- a/wp-content/themes/clarity/inc/admin/users/add-agency-admin.php
+++ b/wp-content/themes/clarity/inc/admin/users/add-agency-admin.php
@@ -15,7 +15,7 @@
 
 $capabilities = array(
 
-	'news'							=> true,
+	'news'                          => true,
 	// management
 	'edit_dashboard'                => true,
 	'homepage_all_access'           => true,
@@ -161,6 +161,12 @@ $capabilities = array(
 	'read_private_regional_pages'   => true,
 	'publish_regional_news'         => true,
 	'publish_regional_pages'        => true,
+
+	// allow greater permissions managing polls plugin
+	'edit_polls'                    => true,
+	'edit_poll'                     => true,
+	'create_polls'                  => true,
+	'publish_polls'                 => true,
 );
 
 

--- a/wp-content/themes/clarity/src/components/c-polls/style.styl
+++ b/wp-content/themes/clarity/src/components/c-polls/style.styl
@@ -9,7 +9,7 @@
 // Needs to be outside of this specific component's scope so it is global and will affect wherever the shortcode is used on the site.
 .totalpoll-button, .totalpoll-button-primary, .totalpoll-button-vote {
   cursor: pointer !important;
-  font-size: $innerCore !important;
+  font-size: $outerCore !important;
   box-shadow: 0 2px 0 #003518 !important;
   padding: 14px 24px 10px !important;
   text-decoration: none !important;
@@ -17,6 +17,20 @@
   border: $defaultAgencyColour !important;
   line-height: $innerCore !important;
   border-radius: 0 !important;
+}
+
+.totalpoll-container, .totalpoll-button, .totalpoll-buttons-results {
+    color: white !important;
+}
+
+.totalpoll-question-choices-item-checked .totalpoll-question-choices-item-control, .totalpoll-question-choices-item-checked:hover .totalpoll-question-choices-item-control, .totalpoll-question-choices-item-checked:focus .totalpoll-question-choices-item-control {
+  background-color: $defaultAgencyColour !important;
+  border: none;
+}
+
+.totalpoll-message-error {
+  color: white !important;
+  background-color: #932214 !important;
 }
 
 .totalpoll-choices {
@@ -41,4 +55,12 @@
 
 h4 {
   font-size: $mantle !important;
+}
+
+.totalpoll-question-choices-item-votes-text {
+  font-size: $outerCore !important;
+}
+
+.totalpoll-question-content, .totalpoll-question-choices-item-label{
+  font-size: $outerCore !important;
 }

--- a/wp-content/themes/clarity/src/components/c-polls/view.php
+++ b/wp-content/themes/clarity/src/components/c-polls/view.php
@@ -1,7 +1,7 @@
 <!-- Note 
 
 This component is currently not being used anywhere on the site, however,
-it's CSS style file is being used to determine the style of the poll plugin widget so that
+its CSS style file is being used to determine the style of the poll plugin widget when displayed, so that
 its styling is compatible with the site.
 
 -->

--- a/wp-content/themes/clarity/src/components/c-polls/view.php
+++ b/wp-content/themes/clarity/src/components/c-polls/view.php
@@ -1,13 +1,4 @@
-<?php
-use MOJ\Intranet\Agency;
-$agency = get_intranet_code();
-$polls  = get_field( $agency . '_homepage_polls_shortcode', 'option' );
-?>
 <!-- c-polls starts here -->
 <section class="c-polls js-polls">
-	<?php
-	echo do_shortcode( $polls );
-	?>
-  <br/>
 </section>
 <!-- c-polls ends here -->

--- a/wp-content/themes/clarity/src/components/c-polls/view.php
+++ b/wp-content/themes/clarity/src/components/c-polls/view.php
@@ -1,4 +1,10 @@
+<!-- Note 
+
+This component is currently not being used anywhere on the site, however,
+it's CSS style file is being used to determine the style of the poll plugin widget so that
+its styling is compatible with the site.
+
+-->
 <!-- c-polls starts here -->
-<section class="c-polls js-polls">
-</section>
+<section class="c-polls js-polls"></section>
 <!-- c-polls ends here -->


### PR DESCRIPTION
TotalPolls completely refactored their poll plugin, breaking some of the
customisation work we had applied to the plugin. For example hiding
paid-for features of the plugin we are not using, in the editor view. A
warning was also thrown as the plugin had changed file names. This has
been fixed.