### PR TITLE
Add GA to error pages

### DIFF
--- a/web/app/themes/clarity/error-pages/403.html
+++ b/web/app/themes/clarity/error-pages/403.html
@@ -389,25 +389,15 @@
     }
   </style>
 
-  <!-- Google Tag Manager -->
-  <script>
-    (function (w, d, s, l, i) {
-      w[l] = w[l] || []
-      w[l].push({
-        'gtm.start': new Date().getTime(),
-        event: 'gtm.js'
-      })
-      var f = d.getElementsByTagName(s)[0],
-        j = d.createElement(s),
-        dl = l != 'dataLayer' ? '&l=' + l : ''
-      j.async = true
-      j.src =
-        '//www.googletagmanager.com/gtm.js?id=' + i + dl
-      f.parentNode.insertBefore(j, f)
-    })(window, document, 'script', 'dataLayer', 'GTM-P545JM')
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-59532760-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-59532760-1');
+</script>
 
-  </script>
-  <!-- End Google Tag Manager -->
 </head>
 
 <body>

--- a/web/app/themes/clarity/error-pages/404.html
+++ b/web/app/themes/clarity/error-pages/404.html
@@ -9,25 +9,15 @@
   <link rel="stylesheet" href="/app/themes/clarity/dist/css/globals.css"/>
   <link rel="stylesheet" href="/app/themes/clarity/dist/css/style.css"/>
 
-  <!-- Google Tag Manager -->
-  <script>
-    (function (w, d, s, l, i) {
-      w[l] = w[l] || []
-      w[l].push({
-        'gtm.start': new Date().getTime(),
-        event: 'gtm.js'
-      })
-      var f = d.getElementsByTagName(s)[0],
-        j = d.createElement(s),
-        dl = l != 'dataLayer' ? '&l=' + l : ''
-      j.async = true
-      j.src =
-        '//www.googletagmanager.com/gtm.js?id=' + i + dl
-      f.parentNode.insertBefore(j, f)
-    })(window, document, 'script', 'dataLayer', 'GTM-P545JM')
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-59532760-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  </script>
-  <!-- End Google Tag Manager -->
+  gtag('config', 'UA-59532760-1');
+</script>
 
 </head>
 

--- a/web/app/themes/clarity/error-pages/500.html
+++ b/web/app/themes/clarity/error-pages/500.html
@@ -9,25 +9,15 @@
   <link rel="stylesheet" href="/app/themes/clarity/dist/css/globals.css"/>
   <link rel="stylesheet" href="/app/themes/clarity/dist/css/style.css"/>
 
-  <!-- Google Tag Manager -->
-  <script>
-    (function (w, d, s, l, i) {
-      w[l] = w[l] || []
-      w[l].push({
-        'gtm.start': new Date().getTime(),
-        event: 'gtm.js'
-      })
-      var f = d.getElementsByTagName(s)[0],
-        j = d.createElement(s),
-        dl = l != 'dataLayer' ? '&l=' + l : ''
-      j.async = true
-      j.src =
-        '//www.googletagmanager.com/gtm.js?id=' + i + dl
-      f.parentNode.insertBefore(j, f)
-    })(window, document, 'script', 'dataLayer', 'GTM-P545JM')
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=UA-59532760-1"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  </script>
-  <!-- End Google Tag Manager -->
+  gtag('config', 'UA-59532760-1');
+</script>
 
 </head>
 


### PR DESCRIPTION
Realised these new error pages don't have any GA tracking code on them. They were just copy and pasted from another site. Intranet doesn't have GTM installed only GA. In future we can add GTM maybe.