### PR TITLE
Fix javascript compiling errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,9 +10,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.js]
-indent_size = 2
-
 [Makefile]
 indent_style = tab
 

--- a/web/app/themes/clarity/inc/enqueue.php
+++ b/web/app/themes/clarity/inc/enqueue.php
@@ -19,12 +19,13 @@ function enqueue_clarity_scripts()
     wp_enqueue_style('core-css', mix_asset('/css/globals.css'), array(), null, 'all');
 
     // JS
-    wp_enqueue_script('core-js', mix_asset('/js/main.js'), array('jquery'));
+    wp_enqueue_script('core-js', mix_asset('/js/main.min.js'), array('jquery'));
     wp_localize_script('core-js', 'mojAjax', ['ajaxurl' => admin_url('admin-ajax.php')]);
 
     // Third party vendor scripts
     wp_deregister_script('jquery'); // This removes jquery shipped with WP so that we can add our own.
-    wp_enqueue_script('jquery', mix_asset('/js/jquery.min.js'));
+    wp_register_script('jquery', mix_asset('/js/jquery.min.js'));
+    wp_enqueue_script('jquery');
 
     wp_enqueue_script('popup', mix_asset('/js/magnific-popup.js'), array('jquery'), null, true);
     wp_enqueue_script('html5shiv', mix_asset('/js/ie8-js-html5shiv.js'));

--- a/web/app/themes/clarity/package-lock.json
+++ b/web/app/themes/clarity/package-lock.json
@@ -3402,9 +3402,9 @@
             "dev": true
         },
         "copy-webpack-plugin": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.1.tgz",
-            "integrity": "sha512-P15M5ZC8dyCjQHWwd4Ia/dm0SgVvZJMYeykVIVYXbGyqO4dWB5oyPHp9i7wjwo5LhtlhKbiBCdS2NvM07Wlybg==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.1.2.tgz",
+            "integrity": "sha512-Uh7crJAco3AjBvgAy9Z75CjK8IG+gxaErro71THQ+vv/bl4HaQcpkexAY8KVW/T6D2W2IRr+couF/knIRkZMIQ==",
             "dev": true,
             "requires": {
                 "cacache": "^12.0.3",
@@ -3417,7 +3417,7 @@
                 "normalize-path": "^3.0.0",
                 "p-limit": "^2.2.1",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^2.1.2",
+                "serialize-javascript": "^4.0.0",
                 "webpack-log": "^2.0.0"
             },
             "dependencies": {
@@ -6630,9 +6630,9 @@
             "dev": true
         },
         "is-docker": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-            "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+            "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
         },
         "is-extendable": {
             "version": "0.1.1",
@@ -7788,15 +7788,15 @@
             }
         },
         "node-notifier": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.1.tgz",
-            "integrity": "sha512-VkzhierE7DBmQEElhTGJIoiZa1oqRijOtgOlsXg32KrJRXsPy0NXFBqWGW/wTswnJlDCs5viRYaqWguqzsKcmg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.2.tgz",
+            "integrity": "sha512-ux+n4hPVETuTL8+daJXTOC6uKLgMsl1RYfFv7DKRzyvzBapqco0rZZ9g72ZN8VS6V+gvNYHYa/ofcCY8fkJWsA==",
             "requires": {
                 "growly": "^1.3.0",
-                "is-wsl": "^2.1.1",
-                "semver": "^7.2.1",
+                "is-wsl": "^2.2.0",
+                "semver": "^7.3.2",
                 "shellwords": "^0.1.1",
-                "uuid": "^7.0.3",
+                "uuid": "^8.2.0",
                 "which": "^2.0.2"
             },
             "dependencies": {
@@ -7806,9 +7806,9 @@
                     "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
                 },
                 "uuid": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-                    "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+                    "version": "8.3.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
+                    "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
                 },
                 "which": {
                     "version": "2.0.2",
@@ -10175,10 +10175,13 @@
             }
         },
         "serialize-javascript": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
-            "integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==",
-            "dev": true
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
         },
         "serve-index": {
             "version": "1.9.1",

--- a/web/app/themes/clarity/package.json
+++ b/web/app/themes/clarity/package.json
@@ -31,12 +31,10 @@
         "ctgen": "^1.6.6",
         "del": "^5.1.0",
         "jquery": "^3.5.1",
-        "node-notifier": "^7.0.1"
+        "node-notifier": "^7.0.2"
     },
     "devDependencies": {
-        "@babel/core": "^7.11.4",
-        "@babel/preset-env": "^7.11.0",
-        "copy-webpack-plugin": "^5.0.5",
+        "copy-webpack-plugin": "^5.1.2",
         "cssnano": "^4.1.10",
         "imagemin-webpack-plugin": "^2.4.2",
         "jeet": "^7.2.0",

--- a/web/app/themes/clarity/src/components/c-feedback-form/feedback-form.js
+++ b/web/app/themes/clarity/src/components/c-feedback-form/feedback-form.js
@@ -1,13 +1,12 @@
-;
-(function ($) {
-  $.fn.moji_feedbackForm = function () {
-    var form = $('.js-reveal-target')
-    var trigger = $('.js-reveal-trigger')
-    trigger.click(
-      function (e) {
-        e.preventDefault()
-        form.toggle()
-      }
-    )
-  }
-})(jQuery)
+export default (function ($) {
+    $.fn.moji_feedbackForm = function () {
+        let form = $('.js-reveal-target')
+        let trigger = $('.js-reveal-trigger')
+        trigger.click(
+            function (e) {
+                e.preventDefault()
+                form.toggle()
+            }
+        )
+    }
+})(jQuery);

--- a/web/app/themes/clarity/src/components/c-gallery-lightbox/feature-video.js
+++ b/web/app/themes/clarity/src/components/c-gallery-lightbox/feature-video.js
@@ -1,11 +1,10 @@
-;
-(function ($) {
-  $.fn.moji_featureVideo = function () {
-    $('.popup-youtube').magnificPopup({
-      type: 'iframe'
-    })
-    $('.popup-image').magnificPopup({
-      type: 'image'
-    })
-  }
+export default (function ($) {
+    $.fn.moji_featureVideo = function () {
+        $('.popup-youtube').magnificPopup({
+            type: 'iframe'
+        })
+        $('.popup-image').magnificPopup({
+            type: 'image'
+        })
+    }
 })(jQuery)

--- a/web/app/themes/clarity/src/components/c-left-hand-menu/left-hand-menu.js
+++ b/web/app/themes/clarity/src/components/c-left-hand-menu/left-hand-menu.js
@@ -1,28 +1,27 @@
-;
-(function ($) {
-  $.fn.moji_leftHandMenu = function () {
-    var listItem = this.find('li')
-    listItem.each(
-      function () {
-        // If the list item has children and is not the active item then hide its children.
-        if ($(this).hasClass('page_item_has_children') && !$(this).hasClass('current_page_item')) {
-          $(this).addClass('u-closed')
-        }
-        // If the list item has children, attach a click event to each directly descended anchor element
-        $(this).filter('.page_item_has_children').find('> a .dropdown').on(
-          'click',
-          function (e) {
-            if ($(this).parentsUntil('ul').hasClass('u-closed')) {
-              e.preventDefault()
-              $(this).parentsUntil('ul').removeClass('u-closed')
-            } else {
-              e.preventDefault()
-              $(this).parentsUntil('ul').addClass('u-closed')
+export default (function ($) {
+    $.fn.moji_leftHandMenu = function () {
+        var listItem = this.find('li')
+        listItem.each(
+            function () {
+                // If the list item has children and is not the active item then hide its children.
+                if ($(this).hasClass('page_item_has_children') && !$(this).hasClass('current_page_item')) {
+                    $(this).addClass('u-closed')
+                }
+                // If the list item has children, attach a click event to each directly descended anchor element
+                $(this).filter('.page_item_has_children').find('> a .dropdown').on(
+                    'click',
+                    function (e) {
+                        if ($(this).parentsUntil('ul').hasClass('u-closed')) {
+                            e.preventDefault()
+                            $(this).parentsUntil('ul').removeClass('u-closed')
+                        } else {
+                            e.preventDefault()
+                            $(this).parentsUntil('ul').addClass('u-closed')
+                        }
+                    }
+                )
             }
-          }
         )
-      }
-    )
-    return this
-  }
-})(jQuery)
+        return this
+    }
+})(jQuery);

--- a/web/app/themes/clarity/src/components/c-tabbed-content/tabbed-content.js
+++ b/web/app/themes/clarity/src/components/c-tabbed-content/tabbed-content.js
@@ -1,31 +1,30 @@
-; /* tabbedContent function  */
-(function ($) {
-  $.fn.moji_tabbedContent = function () {
-    // create panels var then assign u-current to first panel to display first panel
-    var panels = $('.js-tabbed-content')
-    panels.filter(':first-of-type').show().addClass('u-current')
+export default (function ($) {
+    $.fn.moji_tabbedContent = function () {
+        // create panels var then assign u-current to first panel to display first panel
+        var panels = $('.js-tabbed-content')
+        panels.filter(':first-of-type').show().addClass('u-current')
 
-    // create tabs var then assign u-current to first tab to display first tab
-    var tabs = $('.c-tabbed-content__nav li')
-    $('.c-tabbed-content__nav li:first-child').addClass('u-current')
+        // create tabs var then assign u-current to first tab to display first tab
+        var tabs = $('.c-tabbed-content__nav li')
+        $('.c-tabbed-content__nav li:first-child').addClass('u-current')
 
-    // remove  nav styling if there is less than 1 tab
-    if (tabs.length < 1) {
-      $('.c-tabbed-content__nav').hide()
+        // remove  nav styling if there is less than 1 tab
+        if (tabs.length < 1) {
+            $('.c-tabbed-content__nav').hide()
+        }
+
+        tabs.click(
+            function () {
+                // Hide panel
+                tabs.removeClass('u-current')
+                panels.removeClass('u-current')
+                panels.hide()
+
+                // show panel
+                $(this).addClass('u-current')
+                var thisTab = $(this).text()
+                panels.filter('[data-tab-title="' + thisTab + '"]').show().addClass('u-current')
+            }
+        )
     }
-
-    tabs.click(
-      function () {
-        // Hide panel
-        tabs.removeClass('u-current')
-        panels.removeClass('u-current')
-        panels.hide()
-
-        // show panel
-        $(this).addClass('u-current')
-        var thisTab = $(this).text()
-        panels.filter('[data-tab-title="' + thisTab + '"]').show().addClass('u-current')
-      }
-    )
-  }
-})(jQuery)
+})(jQuery);

--- a/web/app/themes/clarity/src/globals/js/blog-content_filter.js
+++ b/web/app/themes/clarity/src/globals/js/blog-content_filter.js
@@ -1,175 +1,174 @@
-;
-(function ($) {
-  $.fn.moji_ajaxFilter = function () {
-    jQuery(document).on('submit', '#ff', function (e) {
-      e.preventDefault()
+export default (function ($) {
+    $.fn.moji_ajaxFilter = function () {
+        jQuery(document).on('submit', '#ff', function (e) {
+            e.preventDefault()
 
-      var nextPageToRetrieve = jQuery('#ff').data('page') + 1
-      jQuery('.more-btn').attr('data-page', nextPageToRetrieve)
+            var nextPageToRetrieve = jQuery('#ff').data('page') + 1
+            jQuery('.more-btn').attr('data-page', nextPageToRetrieve)
 
-      var $input = jQuery(this).find('input[name="ff_keywords_filter"]')
-      var query = $input.val()
-      var $content = jQuery('#content')
-      var nonce = $('#_search_filter_wpnonce').val()
+            var $input = jQuery(this).find('input[name="ff_keywords_filter"]')
+            var query = $input.val()
+            var $content = jQuery('#content')
+            var nonce = $('#_search_filter_wpnonce').val()
 
-      var optionSelected = jQuery(this).find('#ff_date_filter option:selected, #ff_region_news_date_filter option:selected')
-      var valueSelected = optionSelected.val()
-      var newsCategorySelected = jQuery(this).find('#ff_categories_filter_e-news, input[name="ff_categories_filter_regions"]')
-      var newsCategoryValue = newsCategorySelected.val()
+            var optionSelected = jQuery(this).find('#ff_date_filter option:selected, #ff_region_news_date_filter option:selected')
+            var valueSelected = optionSelected.val()
+            var newsCategorySelected = jQuery(this).find('#ff_categories_filter_e-news, input[name="ff_categories_filter_regions"]')
+            var newsCategoryValue = newsCategorySelected.val()
 
-      var postType = jQuery('.data-type').data('type')
-      var termID = jQuery('.l-secondary').data('termid')
+            var postType = jQuery('.data-type').data('type')
+            var termID = jQuery('.l-secondary').data('termid')
 
-      if (newsCategoryValue === 'undefined') {
-        newsCategoryValue = 0
-      }
+            if (newsCategoryValue === 'undefined') {
+                newsCategoryValue = 0
+            }
 
-      jQuery.ajax({
-        type: 'post',
-        url: mojAjax.ajaxurl,
-        dataType: 'html',
-        data: {
-          action: 'load_search_results',
-          query: query,
-          valueSelected: valueSelected,
-          postType: postType,
-          newsCategoryValue: newsCategoryValue,
-          termID: termID,
-          nonce_hash: nonce
-        },
-        success: function (response) {
-          $('.c-article-item').remove()
-          $content.html(response)
-        }
-      })
+            jQuery.ajax({
+                type: 'post',
+                url: mojAjax.ajaxurl,
+                dataType: 'html',
+                data: {
+                    action: 'load_search_results',
+                    query: query,
+                    valueSelected: valueSelected,
+                    postType: postType,
+                    newsCategoryValue: newsCategoryValue,
+                    termID: termID,
+                    nonce_hash: nonce
+                },
+                success: function (response) {
+                    $('.c-article-item').remove()
+                    $content.html(response)
+                }
+            })
 
-      jQuery.ajax({
-        type: 'post',
-        url: mojAjax.ajaxurl,
-        dataType: 'html',
-        data: {
-          action: 'load_search_results_total',
-          query: query,
-          valueSelected: valueSelected,
-          postType: postType,
-          newsCategoryValue: newsCategoryValue,
-          termID: termID,
-          nonce_hash: nonce
-        },
-        success: function (response) {
-          jQuery('#title-section').html(response)
-        }
-      })
+            jQuery.ajax({
+                type: 'post',
+                url: mojAjax.ajaxurl,
+                dataType: 'html',
+                data: {
+                    action: 'load_search_results_total',
+                    query: query,
+                    valueSelected: valueSelected,
+                    postType: postType,
+                    newsCategoryValue: newsCategoryValue,
+                    termID: termID,
+                    nonce_hash: nonce
+                },
+                success: function (response) {
+                    jQuery('#title-section').html(response)
+                }
+            })
 
-      jQuery.ajax({
-        type: 'post',
-        url: mojAjax.ajaxurl,
-        dataType: 'html',
-        data: {
-          action: 'load_page_total',
-          query: query,
-          nextPageToRetrieve: nextPageToRetrieve,
-          valueSelected: valueSelected,
-          postType: postType,
-          newsCategoryValue: newsCategoryValue,
-          termID: termID,
-          nonce_hash: nonce
-        },
-        success: function (response) {
-          $('.c-pagination').html(response)
-        }
-      })
-      return false
-    })
+            jQuery.ajax({
+                type: 'post',
+                url: mojAjax.ajaxurl,
+                dataType: 'html',
+                data: {
+                    action: 'load_page_total',
+                    query: query,
+                    nextPageToRetrieve: nextPageToRetrieve,
+                    valueSelected: valueSelected,
+                    postType: postType,
+                    newsCategoryValue: newsCategoryValue,
+                    termID: termID,
+                    nonce_hash: nonce
+                },
+                success: function (response) {
+                    $('.c-pagination').html(response)
+                }
+            })
+            return false
+        })
 
-    jQuery('.c-pagination').on('click', function () {
-      var nonce = $('#_search_filter_wpnonce').val()
-      var nextPageToRetrieve = jQuery('.more-btn').data('page') + 1
-      jQuery('.more-btn').attr('data-page', nextPageToRetrieve)
-      var query = jQuery('#ff_keywords_filter').val()
-      var valueSelected = jQuery('.more-btn, .nomore-btn').data('date')
-      var postType = jQuery('.data-type').data('type')
-      var newsCategorySelected = jQuery('input[name="ff_categories_filter_news-category"]:checked')
-      var newsCategoryValue = newsCategorySelected.val()
-      if (newsCategoryValue === 'undefined') {
-        newsCategoryValue = 0
-      }
+        jQuery('.c-pagination').on('click', function () {
+            var nonce = $('#_search_filter_wpnonce').val()
+            var nextPageToRetrieve = jQuery('.more-btn').data('page') + 1
+            jQuery('.more-btn').attr('data-page', nextPageToRetrieve)
+            var query = jQuery('#ff_keywords_filter').val()
+            var valueSelected = jQuery('.more-btn, .nomore-btn').data('date')
+            var postType = jQuery('.data-type').data('type')
+            var newsCategorySelected = jQuery('input[name="ff_categories_filter_news-category"]:checked')
+            var newsCategoryValue = newsCategorySelected.val()
+            if (newsCategoryValue === 'undefined') {
+                newsCategoryValue = 0
+            }
 
-      jQuery.ajax({
-        type: 'post',
-        url: mojAjax.ajaxurl,
-        dataType: 'html',
-        data: {
-          action: 'load_next_results',
-          query: query,
-          nextPageToRetrieve: nextPageToRetrieve,
-          valueSelected: valueSelected,
-          postType: postType,
-          newsCategoryValue: newsCategoryValue,
-          nonce_hash: nonce
-        },
+            jQuery.ajax({
+                type: 'post',
+                url: mojAjax.ajaxurl,
+                dataType: 'html',
+                data: {
+                    action: 'load_next_results',
+                    query: query,
+                    nextPageToRetrieve: nextPageToRetrieve,
+                    valueSelected: valueSelected,
+                    postType: postType,
+                    newsCategoryValue: newsCategoryValue,
+                    nonce_hash: nonce
+                },
 
-        success: function (response) {
-          $('#load_more').append(response)
-        }
-      })
+                success: function (response) {
+                    $('#load_more').append(response)
+                }
+            })
 
-      jQuery.ajax({
-        type: 'post',
-        url: mojAjax.ajaxurl,
-        dataType: 'html',
-        data: {
-          action: 'load_page_total',
-          query: query,
-          nextPageToRetrieve: nextPageToRetrieve,
-          valueSelected: valueSelected,
-          postType: postType,
-          newsCategoryValue: newsCategoryValue,
-          nonce_hash: nonce
-        },
-        success: function (response) {
-          $('.c-pagination').html(response)
-        }
-      })
-      return false
-    })
+            jQuery.ajax({
+                type: 'post',
+                url: mojAjax.ajaxurl,
+                dataType: 'html',
+                data: {
+                    action: 'load_page_total',
+                    query: query,
+                    nextPageToRetrieve: nextPageToRetrieve,
+                    valueSelected: valueSelected,
+                    postType: postType,
+                    newsCategoryValue: newsCategoryValue,
+                    nonce_hash: nonce
+                },
+                success: function (response) {
+                    $('.c-pagination').html(response)
+                }
+            })
+            return false
+        })
 
-    jQuery(document).on('submit', '#ff_events', function (e) {
-      e.preventDefault()
+        jQuery(document).on('submit', '#ff_events', function (e) {
+            e.preventDefault()
 
-      var nextPageToRetrieve = jQuery('#ff').data('page') + 1
-      jQuery('.more-btn').attr('data-page', nextPageToRetrieve)
+            var nextPageToRetrieve = jQuery('#ff').data('page') + 1
+            jQuery('.more-btn').attr('data-page', nextPageToRetrieve)
 
-      var $input = jQuery(this).find('input[name="ff_keywords_filter"]')
-      var query = $input.val()
-      var $content = jQuery('#content')
+            var $input = jQuery(this).find('input[name="ff_keywords_filter"]')
+            var query = $input.val()
+            var $content = jQuery('#content')
 
-      var optionSelected = jQuery(this).find('#ff_date_filter option:selected')
-      var valueSelected = optionSelected.val()
+            var optionSelected = jQuery(this).find('#ff_date_filter option:selected')
+            var valueSelected = optionSelected.val()
 
-      var postType = jQuery('.data-type').data('type')
-      var termID = jQuery('.l-secondary').data('termid')
+            var postType = jQuery('.data-type').data('type')
+            var termID = jQuery('.l-secondary').data('termid')
 
-      var nonce = $('#_search_filter_wpnonce').val()
+            var nonce = $('#_search_filter_wpnonce').val()
 
-      jQuery.ajax({
-        type: 'post',
-        url: mojAjax.ajaxurl,
-        dataType: 'html',
-        data: {
-          action: 'load_events_filter_results',
-          query: query,
-          valueSelected: valueSelected,
-          postType: postType,
-          termID: termID,
-          nonce_hash: nonce
-        },
-        success: function (response) {
-          $('.c-article-item').remove()
-          $content.html(response)
-        }
-      })
-      return false
-    })
-  }
+            jQuery.ajax({
+                type: 'post',
+                url: mojAjax.ajaxurl,
+                dataType: 'html',
+                data: {
+                    action: 'load_events_filter_results',
+                    query: query,
+                    valueSelected: valueSelected,
+                    postType: postType,
+                    termID: termID,
+                    nonce_hash: nonce
+                },
+                success: function (response) {
+                    $('.c-article-item').remove()
+                    $content.html(response)
+                }
+            })
+            return false
+        })
+    }
 })(jQuery)

--- a/web/app/themes/clarity/src/globals/js/condolences-filter.js
+++ b/web/app/themes/clarity/src/globals/js/condolences-filter.js
@@ -1,5 +1,4 @@
-;
-(function ($) {
+export default (function ($) {
     $.fn.moji_condolencesFilter = function () {
         jQuery(document).on('submit', '#filter_condolences', function (e) {
             e.preventDefault();
@@ -30,4 +29,4 @@
 
 
     }
-})(jQuery)
+})(jQuery);

--- a/web/app/themes/clarity/src/globals/js/equaliser.js
+++ b/web/app/themes/clarity/src/globals/js/equaliser.js
@@ -1,27 +1,26 @@
-;
-(function ($) {
-  /**
-   * Ensures that in a set of elements, they all have an equal height (equal to the height of the largest elemement)
-   *
-   * Usage: Simply add your container element to script-loader.js and add .moji_equaliser() on to it.
-   * Make sure you reference the container and child elements. e.g. $('.c-news-list > .js-article-item').moji_equaliser()
-   *
-   */
-  $.fn.moji_equaliser = function () {
-    var container = this
-    var tallestHeight = 0
-    var heightCheck = 1
-    for (var i = 0; i < container.length; i++) {
-      var height = $(container[i]).outerHeight(true)
-      if (height > tallestHeight) tallestHeight = height
-      if (heightCheck === container.length) {
-        // All items accounted for, now make all items the same height
-        $(container).css('height', tallestHeight + 'px')
-      } else {
-        heightCheck++
-      }
-    }
+export default (function ($) {
+    /**
+     * Ensures that in a set of elements, they all have an equal height (equal to the height of the largest elemement)
+     *
+     * Usage: Simply add your container element to script-loader.js and add .moji_equaliser() on to it.
+     * Make sure you reference the container and child elements. e.g. $('.c-news-list > .js-article-item').moji_equaliser()
+     *
+     */
+    $.fn.moji_equaliser = function () {
+        var container = this
+        var tallestHeight = 0
+        var heightCheck = 1
+        for (var i = 0; i < container.length; i++) {
+            var height = $(container[i]).outerHeight(true)
+            if (height > tallestHeight) tallestHeight = height
+            if (heightCheck === container.length) {
+                // All items accounted for, now make all items the same height
+                $(container).css('height', tallestHeight + 'px')
+            } else {
+                heightCheck++
+            }
+        }
 
-    return container
-  }
+        return container
+    }
 })(jQuery)

--- a/web/app/themes/clarity/src/globals/js/script-loader.js
+++ b/web/app/themes/clarity/src/globals/js/script-loader.js
@@ -1,23 +1,36 @@
-/*
+/**
+ Script loader
+ In order to avoid performance issues, scripts are not automatically
+ loaded when a component is generated. You must explicitly import and execute your scripts here.
+ */
 
-Script loader
+// component script registration
+import "../../components/c-feedback-form/feedback-form";
+import "../../components/c-gallery-lightbox/feature-video";
+import "../../components/c-left-hand-menu/left-hand-menu";
+import "../../components/c-tabbed-content/tabbed-content";
 
-In order to avoid performance issues, scripts are not automatically
-loaded when a component is generated. You must explicitly execute your scripts here.
+// Global scripts
+import "./blog-content_filter";
+import "./condolences-filter";
+import "./equaliser";
+import "./slider";
 
-You can attach a script to any element but please put a js- class for any hooks to ensure future proofing.
-
-*/
+/**
+ You can attach a script to any element but please put a js- class for any hooks to ensure future proofing.
+ */
 jQuery(function ($) {
-  // Tell the css that JavaScript has loaded successfully
-  $('html').removeClass('no-js').addClass('js')
-  // Load scripts
-  $('.js-left-hand-menu').moji_leftHandMenu()
-  $('.js-feature-video').moji_featureVideo()
-  $('.c-news-list > .js-article-item').moji_equaliser()
-  // This script is attached to a template and not a component
-  $('.js-tabbed-content-container').moji_tabbedContent()
-  $('.js-reveal').moji_feedbackForm()
-  $('.js-blog-content-ajaxfilter').moji_ajaxFilter()
-  $('.js-condolences-filter').moji_condolencesFilter()
-})
+    // Let css know that JavaScript has loaded successfully
+    $('html').removeClass('no-js').addClass('js')
+
+    // Load global scripts
+    $('.js-left-hand-menu').moji_leftHandMenu()
+    $('.js-feature-video').moji_featureVideo()
+    $('.c-news-list > .js-article-item').moji_equaliser()
+
+    // Load component scripts
+    $('.js-tabbed-content-container').moji_tabbedContent()
+    $('.js-reveal').moji_feedbackForm()
+    $('.js-blog-content-ajaxfilter').moji_ajaxFilter()
+    $('.js-condolences-filter').moji_condolencesFilter()
+});

--- a/web/app/themes/clarity/src/globals/js/slider.js
+++ b/web/app/themes/clarity/src/globals/js/slider.js
@@ -1,50 +1,50 @@
-;(function ($) {
-  /**
- * Turns a set of elements into a slideshow
- *
- * Usage: Simply add your slideshow container element to script-loader.js and add .moji_slider() on to it.
- * In order for this to work you will need to enable one or both of the following options:
- *
- * @navigation {boolean} [default: false] true shows a 'back/next' navigation which can be styled with CSS.
- * @interval {integer} [default: 0] adding a value will cause the slideshow to autoplay using the set interval value in milliseconds (1000ms = 1s)
- */
-  $.fn.moji_slider = function (navigation, interval) {
-    var container = this
-    var slide = container.find('.js-slide')
-    var slideCount = slide.length
-    var current = 1
-    // Switches between slides
-    var slider = function () {
-      // TODO: This is a bit rudementary at the moment.
-      // It might be nice in the future to add some animations to this
-      slide.hide().attr('aria-hidden', true).attr('hidden', 'hidden')
-      slide.eq(current - 1).show().attr('aria-hidden', false).removeAttr('hidden')
-    }
+export default (function ($) {
+    /**
+     * Turns a set of elements into a slideshow
+     *
+     * Usage: Simply add your slideshow container element to script-loader.js and add .moji_slider() on to it.
+     * In order for this to work you will need to enable one or both of the following options:
+     *
+     * @navigation {boolean} [default: false] true shows a 'back/next' navigation which can be styled with CSS.
+     * @interval {integer} [default: 0] adding a value will cause the slideshow to autoplay using the set interval value in milliseconds (1000ms = 1s)
+     */
+    $.fn.moji_slider = function (navigation, interval) {
+        var container = this
+        var slide = container.find('.js-slide')
+        var slideCount = slide.length
+        var current = 1
+        // Switches between slides
+        var slider = function () {
+            // TODO: This is a bit rudementary at the moment.
+            // It might be nice in the future to add some animations to this
+            slide.hide().attr('aria-hidden', true).attr('hidden', 'hidden')
+            slide.eq(current - 1).show().attr('aria-hidden', false).removeAttr('hidden')
+        }
 
-    // Switch between current slides, it will move forward unless specified otherwise
-    var switchSlide = function (dir) {
-      slider()
-      if (dir === 'back') {
-        current = (current > 1) ? current - 1 : slideCount
-      } else {
-        current = (current < slideCount) ? current + 1 : 1
-      }
-    }
+        // Switch between current slides, it will move forward unless specified otherwise
+        var switchSlide = function (dir) {
+            slider()
+            if (dir === 'back') {
+                current = (current > 1) ? current - 1 : slideCount
+            } else {
+                current = (current < slideCount) ? current + 1 : 1
+            }
+        }
 
-    // Create the navigation and bind events to it
-    var useNav = function () {
-      slider() // activate the slider once
-      var navContainer = $('<div class="js-nav-container" />')
-      var backLink = $('<button aria-label="back" class="js-nav-back u-icon u-icon--circle-left"></button>')
-      var nextLink = $('<button aria-label="next" class="js-nav-next u-icon u-icon--circle-right"></button>')
-      navContainer.appendTo(container).append(backLink).append(nextLink)
-      navContainer.on('click', '.js-nav-back', function () { switchSlide('back') })
-      navContainer.on('click', '.js-nav-next', function () { switchSlide('next') })
+        // Create the navigation and bind events to it
+        var useNav = function () {
+            slider() // activate the slider once
+            var navContainer = $('<div class="js-nav-container" />')
+            var backLink = $('<button aria-label="back" class="js-nav-back u-icon u-icon--circle-left"></button>')
+            var nextLink = $('<button aria-label="next" class="js-nav-next u-icon u-icon--circle-right"></button>')
+            navContainer.appendTo(container).append(backLink).append(nextLink)
+            navContainer.on('click', '.js-nav-back', function () { switchSlide('back') })
+            navContainer.on('click', '.js-nav-next', function () { switchSlide('next') })
+        }
+        // Check to see if the slider should be on a timer
+        if (interval > 0) setInterval(switchSlide, interval)
+        // Check to see if the slider should be manually navigated
+        if (navigation === true) useNav()
+        return container
     }
-    // Check to see if the slider should be on a timer
-    if (interval > 0) setInterval(switchSlide, interval)
-    // Check to see if the slider should be manually navigated
-    if (navigation === true) useNav()
-    return container
-  }
 })(jQuery)

--- a/web/app/themes/clarity/webpack.mix.js
+++ b/web/app/themes/clarity/webpack.mix.js
@@ -7,12 +7,7 @@ require('laravel-mix-imagemin')
 mix.setPublicPath('./dist/')
 
 /*******************/
-mix.js(
-    [
-        'src/globals/js/script-loader.js'
-    ],
-    'dist/js/main.min.js'
-)
+mix.js('src/globals/js/script-loader.js', 'dist/js/main.min.js')
     .stylus('src/globals/css/_init.styl', 'dist/css/globals.css', { use: stylDeps })
     .stylus('src/components/style.print.styl', 'dist/css/', { use: stylDeps })
     .stylus('src/components/style.ie.styl', 'dist/css/', { use: stylDeps })

--- a/web/app/themes/clarity/webpack.mix.js
+++ b/web/app/themes/clarity/webpack.mix.js
@@ -7,35 +7,34 @@ require('laravel-mix-imagemin')
 mix.setPublicPath('./dist/')
 
 /*******************/
-
-mix.babel([
-  'src/globals/js/*.js',
-  'src/components/**/*.js'
-],
-'dist/js/main.js'
+mix.js(
+    [
+        'src/globals/js/script-loader.js'
+    ],
+    'dist/js/main.min.js'
 )
-  .stylus('src/globals/css/_init.styl', 'dist/css/globals.css', { use: stylDeps })
-  .stylus('src/components/style.print.styl', 'dist/css/', { use: stylDeps })
-  .stylus('src/components/style.ie.styl', 'dist/css/', { use: stylDeps })
-  .stylus('src/components/style.ie8.styl', 'dist/css/', { use: stylDeps })
-  .stylus('src/components/style.styl', 'dist/css/', { use: stylDeps })
-  .imagemin([
-    'images/**.*',
-    'images/*/**.*'
-  ],
-  { context: 'src/globals' },
-    {
-      optipng: {optimizationLevel: 5},
-      jpegtran: null
-    }
-  )
-  .copy('src/vendors/*', 'dist/js/')
-  .copy('./node_modules/jquery/dist/jquery.min.js', 'dist/js/')
-  .copy('src/globals/fonts/*', 'dist/fonts/')
-  .options({ processCssUrls: false })
+    .stylus('src/globals/css/_init.styl', 'dist/css/globals.css', { use: stylDeps })
+    .stylus('src/components/style.print.styl', 'dist/css/', { use: stylDeps })
+    .stylus('src/components/style.ie.styl', 'dist/css/', { use: stylDeps })
+    .stylus('src/components/style.ie8.styl', 'dist/css/', { use: stylDeps })
+    .stylus('src/components/style.styl', 'dist/css/', { use: stylDeps })
+    .imagemin([
+            'images/**.*',
+            'images/*/**.*'
+        ],
+        { context: 'src/globals' },
+        {
+            optipng: { optimizationLevel: 5 },
+            jpegtran: null
+        }
+    )
+    .copy('src/vendors/*', 'dist/js/')
+    .copy('./node_modules/jquery/dist/jquery.min.js', 'dist/js/')
+    .copy('src/globals/fonts/*', 'dist/fonts/')
+    .options({ processCssUrls: false })
 
 if (mix.inProduction()) {
-  mix.version()
+    mix.version()
 } else {
-  mix.sourceMaps()
+    mix.sourceMaps()
 }


### PR DESCRIPTION
Readjusted Laravel mix to remove babel and process javascript files efficiently
I found a script that loads all the JavaScript objects called `script-loader.js`. It's potentially a great little script as it loads objects only when they are needed. In line with ES6 I have converted the component scripts (as well as global scripts) to exportable modules and imported them in the `script-loader.js` file as dependencies for the loader. There are 2 benefits here:

- we don't need to maintain babel anymore
- we can keep the location of script dependencies in one place

I can't see any cons for this approach, the script-loader always needs updating when a component with a script is added which is why moving dependancies here works well.