### PR TITLE
Update APIs to use servername not localhost IP

### DIFF
--- a/web/app/themes/clarity/inc/api/get-campaign-news-api.php
+++ b/web/app/themes/clarity/inc/api/get-campaign-news-api.php
@@ -11,11 +11,9 @@ function get_campaign_news_api($campaign_id)
     $agency_name   = '&agency=' . $activeAgency['wp_tag_id'];
     $campaign_name = '&campaign_category=' . $campaign_id;
 
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
+ 
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
     $response = wp_remote_get($siteurl . '/wp-json/wp/v2/news/?' . $post_per_page . $current_page . $agency_name . $campaign_name);
 

--- a/web/app/themes/clarity/inc/api/get-campaign-posts-api.php
+++ b/web/app/themes/clarity/inc/api/get-campaign-posts-api.php
@@ -11,11 +11,9 @@ function get_campaign_post_api($campaign_id)
     $agency_name   = '&agency=' . $activeAgency['wp_tag_id'];
     $campaign_name = '&campaign_category=' . $campaign_id;
 
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
+
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
     $response = wp_remote_get($siteurl . '/wp-json/wp/v2/posts/?' . $post_per_page . $current_page . $agency_name . $campaign_name);
 

--- a/web/app/themes/clarity/inc/api/get-category-news-api.php
+++ b/web/app/themes/clarity/inc/api/get-category-news-api.php
@@ -11,11 +11,8 @@ function get_category_news_api($category_id)
     $agency_name   = '&agency=' . $activeAgency['wp_tag_id'];
     $category_name = '&news_category=' . $category_id;
 
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
     $response = wp_remote_get($siteurl . '/wp-json/wp/v2/news/?' . $post_per_page . $current_page . $agency_name . $category_name);
 

--- a/web/app/themes/clarity/inc/api/get-news-rest-api.php
+++ b/web/app/themes/clarity/inc/api/get-news-rest-api.php
@@ -24,18 +24,15 @@ function get_news_api($set_cpt = '')
     $region_id         = get_the_terms($post_id, 'region');
     $regional_template = get_post_meta(get_the_ID(), 'dw_regional_template', true);
 
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
+
     if ($region_id) :
         foreach ($region_id as $region) :
             // Current region, ie Scotland, North West etc
             $current_region = '&region=' . $region->term_id;
         endforeach;
     endif;
-
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
 
     switch ($post_type) {
         case 'regional_page':

--- a/web/app/themes/clarity/inc/api/get-posts-rest-api.php
+++ b/web/app/themes/clarity/inc/api/get-posts-rest-api.php
@@ -22,11 +22,8 @@ function get_post_api($blog_posts_number = '10')
     $current_page  = '&page=1';
     $agency_name   = '&agency=' . $activeAgency['wp_tag_id'];
 
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
     $response = wp_remote_get($siteurl . '/wp-json/wp/v2/posts/?' . $post_per_page . $current_page . $agency_name);
 

--- a/web/app/themes/clarity/inc/content-filter/search.php
+++ b/web/app/themes/clarity/inc/content-filter/search.php
@@ -104,12 +104,9 @@ function load_search_results()
         $news_category_name = ( ! empty($newsCategory_ID) ? '&news_category=' . $newsCategory_ID : '' );
     }
 
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
-
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
+    
     $response = wp_remote_get($siteurl . '/wp-json/wp/v2/' . $postType . '/?' . $post_per_page . $agency_name . $valueSelected . $search . $news_category_name);
 
     $post_total = wp_remote_retrieve_header($response, 'x-wp-total');
@@ -154,13 +151,10 @@ function load_next_results()
     $search             = ( ! empty($query) ? '&search=' . $query : '' );
     $agency_name        = '&agency=' . $activeAgency['wp_tag_id'];
     $news_category_name = ( ! empty($newsCategory_ID) ? '&news_category=' . $newsCategory_ID : '' );
-
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
-
+    
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
+    
     $response = wp_remote_get($siteurl . '/wp-json/wp/v2/' . $postType . '/?' . $post_per_page . $current_page . $agency_name . $valueSelected . $search . $news_category_name);
 
     $pagetotal = wp_remote_retrieve_header($response, 'x-wp-totalpages');
@@ -204,11 +198,9 @@ function load_search_results_total()
     $agency_name        = '&agency=' . $activeAgency['wp_tag_id'];
     $news_category_name = ( ! empty($newsCategory_ID) ? '&news_category=' . $newsCategory_ID : '' );
 
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
+
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
     $response   = wp_remote_get($siteurl . '/wp-json/wp/v2/' . $postType . '/?' . $post_per_page . $agency_name . $valueSelected . $search . $news_category_name);
     $post_total = wp_remote_retrieve_header($response, 'x-wp-total');
@@ -245,11 +237,9 @@ function load_page_total()
     $agency_name             = '&agency=' . $activeAgency['wp_tag_id'];
     $news_category_name      = ( ! empty($newsCategory_ID) ? '&news_category=' . $newsCategory_ID : '' );
 
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
+
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
     $response = wp_remote_get($siteurl . '/wp-json/wp/v2/' . $postType . '/?' . $post_per_page . $current_page . $agency_name . $valueSelected  . $search . $news_category_name);
 

--- a/web/app/themes/clarity/inc/newscategory.php
+++ b/web/app/themes/clarity/inc/newscategory.php
@@ -22,11 +22,9 @@ class NewsCategory
         $agency_name        = '&agency=' . $activeAgency['wp_tag_id'];
         $category_name      = '&news_category=' .$category_id;
 
-        /*
-        * A temporary measure so that API calls do not get blocked by
-        * changing IPs not whitelisted. All calls are within container.
-        */
-        $siteurl = 'http://127.0.0.1';
+
+        // Internal http call used by the WordPress API
+    	$siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
         $response = wp_remote_get($siteurl.'/wp-json/wp/v2/news/?' . $post_per_page . $current_page . $agency_name . $category_name);
 

--- a/web/app/themes/clarity/inc/pagination-newscategory.php
+++ b/web/app/themes/clarity/inc/pagination-newscategory.php
@@ -6,11 +6,9 @@ function get_newscategory_pagination($category_id)
     $oAgency = new Agency();
     $activeAgency = $oAgency->getCurrentAgency();
 
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
+
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
     $post_per_page      = 'per_page=10';
     $current_page       = '&page=1';

--- a/web/app/themes/clarity/inc/pagination.php
+++ b/web/app/themes/clarity/inc/pagination.php
@@ -5,13 +5,10 @@ function get_pagination($type, $category_id = false)
 {
     $oAgency      = new Agency();
     $activeAgency = $oAgency->getCurrentAgency();
-
-    /*
-    * A temporary measure so that API calls do not get blocked by
-    * changing IPs not whitelisted. All calls are within container.
-    */
-    $siteurl = 'http://127.0.0.1';
-
+   
+    // Internal http call used by the WordPress API
+    $siteurl = 'http://' . $_SERVER['SERVER_NAME'];
+    
     $post_per_page = 'per_page=10';
     $current_page  = '&page=1';
     $agency_name   = '&agency=' . $activeAgency['wp_tag_id'];

--- a/web/app/themes/clarity/inc/teams.php
+++ b/web/app/themes/clarity/inc/teams.php
@@ -32,11 +32,8 @@ class Teams
         $current_page  = '&page=1';
         $agency_name   = '&agency=' . $this->page_meta['agency'];
 
-        /*
-        * A temporary measure so that API calls do not get blocked by
-        * changing IPs not whitelisted. All calls are within container.
-        */
-        $siteurl = 'http://127.0.0.1';
+    	// Internal http call used by the WordPress API
+    	$siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
         $response = wp_remote_get($siteurl . '/wp-json/wp/v2/team-news/?' . $post_per_page . $current_page);
 
@@ -69,11 +66,8 @@ class Teams
         $current_page  = '&page=1';
         $agency_name   = '&agency=' . $this->page_meta['agency'];
 
-        /*
-        * A temporary measure so that API calls do not get blocked by
-        * changing IPs not whitelisted. All calls are within container.
-        */
-        $siteurl = 'http://127.0.0.1';
+    	// Internal http call used by the WordPress API
+    	$siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
         $response = wp_remote_get($siteurl . '/wp-json/wp/v2/team-blogs/?' . $post_per_page . $current_page);
 
@@ -107,11 +101,9 @@ class Teams
         $orderby       = '&meta_key=event-start-date';
         $order         = '&order=desc';
 
-        /*
-        * A temporary measure so that API calls do not get blocked by
-        * changing IPs not whitelisted. All calls are within container.
-        */
-        $siteurl = 'http://127.0.0.1';
+
+    	// Internal http call used by the WordPress API
+    	$siteurl = 'http://' . $_SERVER['SERVER_NAME'];
 
         $response = wp_remote_get($siteurl . '/wp-json/wp/v2/team-events/?' . $post_per_page . $current_page . $orderby . $order);
 


### PR DESCRIPTION
This was causing issues with our force login plugin blocking the API.
This fix should allow us to use the plugin and have the APIs working.