### PR TITLE
Revert back to use same Docker base as our other sites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ministryofjustice/wordpress-base:focal
+FROM ministryofjustice/wordpress-base:latest
 
 ADD . /bedrock
 


### PR DESCRIPTION
We can change this back to focal once we generate a base image that is
compatible with m1. In the meantime this is now inline with our other
sites.