### PR TITLE
amended IT email address

### DIFF
--- a/web/app/themes/clarity/src/components/c-register/view.php
+++ b/web/app/themes/clarity/src/components/c-register/view.php
@@ -115,8 +115,8 @@ if (isset($_POST['task']) && $_POST['task'] == 'register') {
             finish the registration.</p>
 
         <p><strong>Any problems?</strong></p>
-        <p>The email will be from <a href="mailto:intranet-support@digital.justice.gov.uk"
-                target="_blank">intranet-support@digital.justice.gov.uk</a>.<p>
+        <p>The email will be from <a href="mailto:wordpress@digital.justice.gov.uk"
+                target="_blank">wordpress@digital.justice.gov.uk</a>.<p>
 
                 <p>If you can’t find it, check your junk folder then add the address to your safe list.
             </p>


### PR DESCRIPTION
- amended registration notification email address from intranet-support@digital.justice.gov.uk to wordpress@digital.justice.gov.uk