### PR TITLE
Fix checksum verification error

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://composer.wp.dsd.io/dist/acf/advanced-custom-fields-pro/acf-advanced-custom-fields-pro-5.12.3.zip",
-                "shasum": "04e7d8b833b96a1d6a2dbe4a0f01726548cc0576"
+                "shasum": "6e5ad7f13808ee28cb46360836eda1185b770527"
             },
             "type": "wordpress-plugin"
         },

--- a/web/app/themes/clarity/src/components/c-intranet-switcher/view.php
+++ b/web/app/themes/clarity/src/components/c-intranet-switcher/view.php
@@ -60,7 +60,7 @@ if (isset($referrer['query'])) {
             if ($agency_id != 'noms') {
                 echo '<li class="c-intranet-switcher__switch c-intranet-switcher__switch--' . $agency_id . $extra_class . ' "><a href="/?agency=' . $agency_id . $referrer['query'] . '">' . $agency['label'] . '</a></li>';
             } else {
-                echo '<li class="c-intranet-switcher__switch c-intranet-switcher__switch--' . $agency_id . $extra_class . ' "><a href="https://intranet.noms.gsi.gov.uk/">' . $agency['label'] . '</a></li>';
+                echo '<li class="c-intranet-switcher__switch c-intranet-switcher__switch--' . $agency_id . $extra_class . ' "><a href="https://justiceuk.sharepoint.com/sites/hmppsintranet">' . $agency['label'] . '</a></li>';
             }
         }
         ?>

--- a/web/app/themes/clarity/src/components/c-intranet-switcher/view.php
+++ b/web/app/themes/clarity/src/components/c-intranet-switcher/view.php
@@ -60,7 +60,7 @@ if (isset($referrer['query'])) {
             if ($agency_id != 'noms') {
                 echo '<li class="c-intranet-switcher__switch c-intranet-switcher__switch--' . $agency_id . $extra_class . ' "><a href="/?agency=' . $agency_id . $referrer['query'] . '">' . $agency['label'] . '</a></li>';
             } else {
-                echo '<li class="c-intranet-switcher__switch c-intranet-switcher__switch--' . $agency_id . $extra_class . ' "><a href="https://justiceuk.sharepoint.com/sites/hmppsintranet">' . $agency['label'] . '</a></li>';
+                echo '<li class="c-intranet-switcher__switch c-intranet-switcher__switch--' . $agency_id . $extra_class . ' "><a href="https://justiceuk.sharepoint.com/sites/HMPPSIntranet">' . $agency['label'] . '</a></li>';
             }
         }
         ?>

--- a/web/app/themes/clarity/src/components/c-intranet-switcher/view.php
+++ b/web/app/themes/clarity/src/components/c-intranet-switcher/view.php
@@ -44,18 +44,18 @@ if (isset($referrer['query'])) {
 
         <?php
 
-	// Temporarily filtering out OSPT/JAC until site is ready to go live
-	// Remove OSPT hardcoded link to old intranet below when site goes live.
-	$modified_agency_array = array_filter( $activeAgencies, function($data) {
-		return !in_array($data["shortcode"], ['jac', 'ospt']);
-	});
+    // Temporarily filtering out OSPT/JAC until site is ready to go live
+    // Remove OSPT hardcoded link to old intranet below when site goes live.
+        $modified_agency_array = array_filter($activeAgencies, function ($data) {
+            return !in_array($data["shortcode"], ['jac', 'ospt']);
+        });
 
         foreach ($modified_agency_array as $agency_id => $agency) {
             if ($current_intranet == $agency_id) {
                 $extra_class = ' u-active';
             } else {
                 $extra_class = '';
-	    }
+            }
 
             if ($agency_id != 'noms') {
                 echo '<li class="c-intranet-switcher__switch c-intranet-switcher__switch--' . $agency_id . $extra_class . ' "><a href="/?agency=' . $agency_id . $referrer['query'] . '">' . $agency['label'] . '</a></li>';


### PR DESCRIPTION
Since the last build took place, the plugin ACF version 5.12.3 was removed from the source and replaced. This action caused the composer shasum to be invalid.

This PR updates the ACF shasum. 

```
The checksum verification of the file failed (downloaded from https://composer.wp.dsd.io/dist/acf/advanced-custom-fields-pro/acf-advanced-custom-fields-pro-5.12.3.zip)
```
