### PR TITLE
CDPT-690 Supporting OpenSearch integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ SERVER_NAME=intranet.docker
 
 ES_INDEX_NAMESPACE=your-name
 SENTRY_DEV_ID=your-name
-ELASTICSEARCH_VERSION=7.4.0
+ELASTICSEARCH_VERSION=7.17.10
+ELASTICSEARCH_HOST=http://elasticsearch:9200
 
 # Generate your keys here: https://roots.io/salts.html
 AUTH_KEY=saltykey

--- a/config/application.php
+++ b/config/application.php
@@ -40,6 +40,9 @@ if (file_exists($env_config)) {
     require_once $env_config;
 }
 
+/** Elasticsearch  /  ElasticPress */
+define("EP_HOST", env('ELASTICSEARCH_HOST'));
+
 /**
  * URLs
  */
@@ -49,9 +52,9 @@ define('WP_SITEURL', env('WP_SITEURL'));
 /**
  * Custom Content Directory
  */
-define('CONTENT_DIR', '/app');
+const CONTENT_DIR = '/app';
 define('WP_CONTENT_DIR', $webroot_dir . CONTENT_DIR);
-define('WP_CONTENT_URL', WP_HOME . CONTENT_DIR);
+const WP_CONTENT_URL = WP_HOME . CONTENT_DIR;
 
 /**
  * DB settings
@@ -60,8 +63,8 @@ define('DB_NAME', env('DB_NAME'));
 define('DB_USER', env('DB_USER'));
 define('DB_PASSWORD', env('DB_PASSWORD'));
 define('DB_HOST', env('DB_HOST') ?: 'localhost');
-define('DB_CHARSET', 'utf8mb4');
-define('DB_COLLATE', '');
+const DB_CHARSET = 'utf8mb4';
+const DB_COLLATE = '';
 $table_prefix = env('DB_PREFIX') ?: 'wp_';
 
 /**
@@ -79,10 +82,10 @@ define('NONCE_SALT', env('NONCE_SALT'));
 /**
  * Custom Settings
  */
-define('AUTOMATIC_UPDATER_DISABLED', true);
-define('DISABLE_WP_CRON', true);
-define('DISALLOW_FILE_EDIT', true);
-define('S3_UPLOADS_BASE_URL', getenv('S3_UPLOADS_BASE_URL') ? getenv('S3_UPLOADS_BASE_URL') : false);
+const AUTOMATIC_UPDATER_DISABLED = true;
+const DISABLE_WP_CRON = true;
+const DISALLOW_FILE_EDIT = true;
+define('S3_UPLOADS_BASE_URL', env('S3_UPLOADS_BASE_URL') ?? false);
 
 /**
  * Bootstrap WordPress

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -1,5 +1,5 @@
 <?php
 /** Development */
-define('SAVEQUERIES', true);
-define('WP_DEBUG', true);
-define('SCRIPT_DEBUG', true);
+const SAVEQUERIES = true;
+const WP_DEBUG = true;
+const SCRIPT_DEBUG = true;

--- a/config/environments/production.php
+++ b/config/environments/production.php
@@ -1,7 +1,10 @@
 <?php
 /** Production */
 ini_set('display_errors', 0);
-define('WP_DEBUG_DISPLAY', false);
-define('SCRIPT_DEBUG', false);
+const WP_DEBUG_DISPLAY = false;
+const SCRIPT_DEBUG = false;
 /** Disable all file modifications including updates and update notifications */
-define('DISALLOW_FILE_MODS', true);
+const DISALLOW_FILE_MODS = true;
+
+/** Elasticsearch  /  ElasticPress */
+const EP_HOST_URL = "https://search-intranet-prod-4ckbj3hdyvuznpnsaustbud6mu.eu-west-1.es.amazonaws.com/";

--- a/config/environments/staging.php
+++ b/config/environments/staging.php
@@ -1,7 +1,9 @@
 <?php
 /** Staging */
 ini_set('display_errors', 0);
-define('WP_DEBUG_DISPLAY', false);
-define('SCRIPT_DEBUG', false);
+const WP_DEBUG_DISPLAY = false;
+const SCRIPT_DEBUG = false;
 /** Disable all file modifications including updates and update notifications */
-define('DISALLOW_FILE_MODS', true);
+const DISALLOW_FILE_MODS = true;
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,14 +44,14 @@ services:
         image: schickling/mailcatcher
         environment:
             VIRTUAL_HOST: mail.${SERVER_NAME}
-            VIRTUAL_PORT: 1080
+            VIRTUAL_PORT: "1080"
 
     phpmyadmin:
         container_name: int-phpmyadmin
-        image: phpmyadmin/phpmyadmin
+        image: phpmyadmin:latest
         environment:
             VIRTUAL_HOST: phpmyadmin.${SERVER_NAME}
-            VIRTUAL_PORT: 9191
+            VIRTUAL_PORT: "9191"
             PMA_HOST: mysql
         depends_on:
             - mysql
@@ -60,10 +60,10 @@ services:
 
     elasticsearch:
         container_name: int-elasticsearch
-        image: docker.elastic.co/elasticsearch/elasticsearch:${ELASTICSEARCH_VERSION}
+        image: elasticsearch:${ELASTICSEARCH_VERSION}
         environment:
             VIRTUAL_HOST: elasticsearch.${SERVER_NAME}
-            VIRTUAL_PORT: 9200
+            VIRTUAL_PORT: "9200"
             xpack.security.enabled: false
             discovery.type: single-node
         ulimits:
@@ -82,10 +82,10 @@ services:
             - "9300:9300"
     kibana:
         container_name: int-kibana
-        image: docker.elastic.co/kibana/kibana:${ELASTICSEARCH_VERSION}
+        image: kibana:${ELASTICSEARCH_VERSION}
         environment:
             VIRTUAL_HOST: kibana.${SERVER_NAME}
-            VIRTUAL_PORT: 5601
+            VIRTUAL_PORT: "5601"
             ELASTICSEARCH_HOSTS: http://elasticsearch:9200/
         ports:
             - "5610:5610"

--- a/web/app/themes/clarity/functions.php
+++ b/web/app/themes/clarity/functions.php
@@ -76,7 +76,7 @@ require_once 'inc/helpers/validation.php';
 require_once 'inc/images.php';
 require_once 'inc/languages.php';
 require_once 'inc/mail.php';
-require_once 'inc/markdown.php';
+require_once 'inc/elasticsearch.php';
 require_once 'inc/menu.php';
 require_once 'inc/utilities.php';
 require_once 'inc/pagination.php';

--- a/web/app/themes/clarity/inc/elasticsearch.php
+++ b/web/app/themes/clarity/inc/elasticsearch.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * ElasticPress; hooks and custom modification
+ */
+
+add_filter('ep_elasticsearch_version', fn($version) => '7.10');
+add_filter('ep_host', fn($host) => env('EP_HOST'));
+
+


### PR DESCRIPTION
In recent findings, AWS OpenSearch (replacement of Elasticsearch) is problematic as ElasticPress does not work with it out of the box. We can do some things to patch the integration; this PR will cover that work and exploration.

**_Some of the work will touch on the following:_**
1. \* Updating the Intranets' CloudFormation template to include a new environment variable
2. Using platform-agnostic software to allow development on M1 chipsets, as well as Intel
3. Exploring AWS OpenSearch and determine how to make it work efficiently with ElasticPress
4. Understanding what our options are should OpenSearch / Elasticsearch not meet our needs

\* Mainly a security feature to prevent accidental interference with our production Elasticsearch instance.