### PR TITLE
CDPT-731 Test array offset with fallback URL on false

### DIFF
--- a/web/app/themes/clarity/inc/admin/plugins/co-authors-plus.php
+++ b/web/app/themes/clarity/inc/admin/plugins/co-authors-plus.php
@@ -114,9 +114,22 @@ if (function_exists('get_coauthors')) {
             $local_avatar = get_user_meta($id_or_email, 'wp_user_avatar', true);
 
             if (is_numeric($local_avatar)) {
-                $url = wp_get_attachment_image_src($local_avatar, 'user-thumb')[0];
+                $url = wp_get_attachment_image_src($local_avatar, 'user-thumb');
+
+                // get a default avatar
+                $avatar = '';
+                if (!$url) {
+                    $user = get_userdata($id_or_email);
+                    if ($user) {
+                        $avatar = 'https://www.gravatar.com/avatar/' . md5(strtolower($user->user_email)) . '?d=mp';
+                    }
+                }
+
+                $url = $url[0] ?? $avatar;
             }
         }
-        return $url;
+
+        // always return an avatar
+        return $url ?: 'https://www.gravatar.com/avatar/?d=mp';
     }
 }


### PR DESCRIPTION
**Ticket:**
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1154?modal=detail&selectedIssue=CDPT-731\

**Context:**
Some users will not allocate themselves an avatar image. This causes the co-author plugin to throw a warning, rendering the user with a broken image.

This update checks if a URL exists. If not, the code will request a default image based on their email address from Gravatar or the default Gravatar 'mystery person avatar.

http://en.gravatar.com/site/implement/images/