### PR TITLE
CDPT-732 Reset previously removed get_region_context()

### DIFF
--- a/web/app/themes/clarity/inc/admin/agency_taxonomies/taxonomies/region.php
+++ b/web/app/themes/clarity/inc/admin/agency_taxonomies/taxonomies/region.php
@@ -259,7 +259,9 @@ class Region extends Taxonomy
             // Not relevant, return early.
             return $caps;
         }
-        
+
+        $context = Region_Context::get_region_context();
+
         if (!has_term($context, 'region', $post_id)) {
             // User does not have permission to edit this post
             $caps[] = 'do_not_allow';


### PR DESCRIPTION
**Ticket:**
https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1154?modal=detail&selectedIssue=CDPT-732

**Context:**
Regions will (on occasion) fire an error stating that $context is undefined. I couldn't replicate the error; however, I did find a line of code that was removed in a previous PR that causes this issue:

https://github.com/ministryofjustice/intranet/commit/b4b2ee10e1e649ea9fa3c3a09f5f3b7b03254b6f#diff-5cf875bf46fc9435a41322a66ebc892638af92996a023b7d676e5ba1a318845dL254

The trouble is, without spending time tracing this code, I cannot determine what the removal of this line did or why it was done. The only impact I can determine at this stage is that the removal of the line of code is causing this issue, as the PR detailed above doesn't offer any information about why it was removed.

We should move this PR to staging and test the impact there.