### PR TITLE
Adjust left-hand menu for regions

### DIFF
--- a/web/app/themes/clarity/inc/admin/lefthand-menu.php
+++ b/web/app/themes/clarity/inc/admin/lefthand-menu.php
@@ -26,6 +26,8 @@ add_filter('menu_order', function ($menu_order) {
         'edit-comments.php',
         'upload.php',
         'edit.php?post_type=document',
+        'edit.php?post_type=regional_pages',
+        'edit.php?post_type=regional_news',
         'edit.php?post_type=poll',
         'separator2',
         'themes.php',


### PR DESCRIPTION
Added regions to the custom menu ordering script.

**_Note entries below Documents:_**

> Regions are only visible when HMCTS view the admin panel. _Notes from Antonia_ is only visible when MoJ HQ are viewing; hence _Notes from Antonia_ is not visible in this menu example.

![Screenshot 2023-06-28 at 11 58 19](https://github.com/ministryofjustice/intranet/assets/47327051/d62916d5-a4d1-4b43-925f-88840d7d299b)
