### PR TITLE
CDPT 790 Fix duplicate breadcrumb path

### DIFF
--- a/web/app/themes/clarity/inc/post-types/regional-page.php
+++ b/web/app/themes/clarity/inc/post-types/regional-page.php
@@ -205,7 +205,7 @@ function clarity_regional_page_post_type()
             false, // 'custom-fields',
 
             /* Displays the Revisions meta box. If set, stores post revisions in the database. */
-            false, // 'revisions',
+            'revisions', // 'revisions',
 
             /* Displays the Attributes meta box with a parent selector and menu_order input box. */
             'page-attributes',

--- a/web/app/themes/clarity/inc/post-types/regional-page.php
+++ b/web/app/themes/clarity/inc/post-types/regional-page.php
@@ -5,247 +5,65 @@ add_action('init', 'clarity_regional_page_post_type');
 /**
  * Registers the 'regional_page' post type
  *
+ * @return void
  * @since  0.1.0
  * @access public
- * @return void
  */
 function clarity_regional_page_post_type()
 {
-
-    /* Set up the arguments for the post type. */
-    $args = array(
-
-        /**
-         * A short description of what your post type is. As far as I know, this isn't used anywhere
-         * in core WordPress.  However, themes may choose to display this on post type archives.
-         */
-        'description'         => __('This is a description for regional pages.', 'Clarity'), // string
-
-        /**
-         * Whether the post type should be used publicly via the admin or by front-end users.  This
-         * argument is sort of a catchall for many of the following arguments.  I would focus more
-         * on adjusting them to your liking than this argument.
-         */
-        'public'              => true, // bool (default is FALSE)
-
-        /**
-         * Whether queries can be performed on the front end as part of parse_request().
-         */
-        'publicly_queryable'  => true, // bool (defaults to 'public').
-
-        /**
-         * Whether to exclude posts with this post type from front end search results.
-         */
-        'exclude_from_search' => false, // bool (defaults to 'public')
-
-        /**
-         * Whether individual post type items are available for selection in navigation menus.
-         */
-        'show_in_nav_menus'   => false, // bool (defaults to 'public')
-
-        /**
-         * Whether to generate a default UI for managing this post type in the admin. You'll have
-         * more control over what's shown in the admin with the other arguments.  To build your
-         * own UI, set this to FALSE.
-         */
-        'show_ui'             => true, // bool (defaults to 'public')
-
-        /**
-         * Whether to show post type in the admin menu. 'show_ui' must be true for this to work.
-         */
-        'show_in_menu'        => true, // bool (defaults to 'show_ui')
-
-        /**
-         * Whether to make this post type available in the WordPress admin bar. The admin bar adds
-         * a link to add a new post type item.
-         */
-        'show_in_admin_bar'   => false, // bool (defaults to 'show_in_menu')
-
-        /**
-         * The position in the menu order the post type should appear. 'show_in_menu' must be true
-         * for this to work.
-         */
-        'menu_position'       => 3, // int (defaults to 25 - below comments)
-
-        /**
-         * The URI to the icon to use for the admin menu item. There is no header icon argument, so
-         * you'll need to use CSS to add one.
-         */
-        'menu_icon'           => 'dashicons-feedback', // string (defaults to use the post icon)
-
-        /**
-         * Whether the posts of this post type can be exported via the WordPress import/export plugin
-         * or a similar plugin.
-         */
-        'can_export'          => true, // bool (defaults to TRUE)
-
-        /**
-         * Whether to delete posts of this type when deleting a user who has written posts.
-         */
-        'delete_with_user'    => true, // bool (defaults to TRUE if the post type supports 'author')
-
-        /**
-         * Whether this post type should allow hierarchical (parent/child/grandchild/etc.) posts.
-         */
-        'hierarchical'        => true, // bool (defaults to FALSE)
-
-        /**
-         * Whether the post type has an index/archive/root page like the "page for posts" for regular
-         * posts. If set to TRUE, the post type name will be used for the archive slug.  You can also
-         * set this to a string to control the exact name of the archive slug.
-         */
-        'has_archive'         => false, // bool|string (defaults to FALSE)
-
-        /**
-         * Sets the query_var key for this post type. If set to TRUE, the post type name will be used.
-         * You can also set this to a custom string to control the exact key.
-         */
-        'query_var'           => true, // bool|string (defaults to TRUE - post type name)
-
-        /**
-         * A string used to build the edit, delete, and read capabilities for posts of this type. You
-         * can use a string or an array (for singular and plural forms).  The array is useful if the
-         * plural form can't be made by simply adding an 's' to the end of the word.  For example,
-         * array( 'box', 'boxes' ).
-         */
-        'capability_type'     => [ 'regional_page', 'regional_pages' ], // string|array (defaults to 'post')
-
-        /**
-         * Whether WordPress should map the meta capabilities (edit_post, read_post, delete_post) for
-         * you.  If set to FALSE, you'll need to roll your own handling of this by filtering the
-         * 'map_meta_cap' hook.
-         */
-        'map_meta_cap'        => true, // bool (defaults to FALSE)
-
-        /**
-         * Provides more precise control over the capabilities than the defaults.  By default, WordPress
-         * will use the 'capability_type' argument to build these capabilities.  More often than not,
-         * this results in many extra capabilities that you probably don't need.  The following is how
-         * I set up capabilities for many post types, which only uses three basic capabilities you need
-         * to assign to roles: 'manage_examples', 'edit_examples', 'create_examples'.  Each post type
-         * is unique though, so you'll want to adjust it to fit your needs.
-         */
-        // 'capabilities' => array(
-        // meta caps (don't assign these to roles)
-        // 'edit_post'              => 'edit_example',
-        // 'read_post'              => 'read_example',
-        // 'delete_post'            => 'delete_example',
-        // primitive/meta caps
-        // 'create_posts'           => 'create_examples',
-        // primitive caps used outside of map_meta_cap()
-        // 'edit_posts'             => 'edit_examples',
-        // 'edit_others_posts'      => 'manage_examples',
-        // 'publish_posts'          => 'manage_examples',
-        // 'read_private_posts'     => 'read',
-        // primitive caps used inside of map_meta_cap()
-        // 'read'                   => 'read',
-        // 'delete_posts'           => 'manage_examples',
-        // 'delete_private_posts'   => 'manage_examples',
-        // 'delete_published_posts' => 'manage_examples',
-        // 'delete_others_posts'    => 'manage_examples',
-        // 'edit_private_posts'     => 'edit_examples',
-        // 'edit_published_posts'   => 'edit_examples'
-        // ),
-
-        /**
-         * How the URL structure should be handled with this post type.  You can set this to an
-         * array of specific arguments or true|false.  If set to FALSE, it will prevent rewrite
-         * rules from being created.
-         */
-        'rewrite'             => array(
-
-            /* The slug to use for individual posts of this type. */
-            'slug'       => 'regional-pages', // string (defaults to the post type name)
-
-            /* Whether to show the $wp_rewrite->front slug in the permalink. */
-            'with_front' => false, // bool (defaults to TRUE)
-
-            /* Whether to allow single post pagination via the <!--nextpage--> quicktag. */
-            'pages'      => true, // bool (defaults to TRUE)
-
-            /* Whether to create feeds for this post type. */
-            'feeds'      => false, // bool (defaults to the 'has_archive' argument)
-
-            /* Assign an endpoint mask to this permalink. */
-            'ep_mask'    => EP_PERMALINK, // const (defaults to EP_PERMALINK)
-        ),
-
-        /**
-         * What WordPress features the post type supports.  Many arguments are strictly useful on
-         * the edit post screen in the admin.  However, this will help other themes and plugins
-         * decide what to do in certain situations.  You can pass an array of specific features or
-         * set it to FALSE to prevent any features from being added.  You can use
-         * add_post_type_support() to add features or remove_post_type_support() to remove features
-         * later.  The default features are 'title' and 'editor'.
-         */
-        'supports'            => array(
-
-            /* Post titles ($post->post_title). */
+    $args = [
+        'description' => __('This is a description for regional pages.', 'Clarity'),
+        'public' => true,
+        'publicly_queryable' => true,
+        'exclude_from_search' => false,
+        'show_in_nav_menus' => false,
+        'show_ui' => true,
+        'show_in_menu' => true,
+        'show_in_admin_bar' => false,
+        'menu_icon' => 'dashicons-feedback',
+        'delete_with_user' => true,
+        'hierarchical' => true,
+        'has_archive' => false,
+        'query_var' => true,
+        'capability_type' => 'regional_page',
+        'map_meta_cap' => true,
+        'rewrite' => [
+            'slug' => 'regional-pages',
+            'with_front' => false,
+            'pages' => true,
+            'feeds' => false
+        ],
+        'supports' => [
             'title',
-
-            /* Post content ($post->post_content). */
             'editor',
-
-            /* Post excerpt ($post->post_excerpt). */
             'excerpt',
-
-            /* Post author ($post->post_author). */
-            false, // 'author',
-
-            /* Featured images (the user's theme must support 'post-thumbnails'). */
             'thumbnail',
-
-            /* Displays comments meta box.  If set, comments (any type) are allowed for the post. */
-            false, // 'comments',
-
-            /* Displays meta box to send trackbacks from the edit post screen. */
-            false, // 'trackbacks',
-
-            /* Displays the Custom Fields meta box. Post meta is supported regardless. */
-            false, // 'custom-fields',
-
-            /* Displays the Revisions meta box. If set, stores post revisions in the database. */
-            'revisions', // 'revisions',
-
-            /* Displays the Attributes meta box with a parent selector and menu_order input box. */
-            'page-attributes',
-
-            /* Displays the Format meta box and allows post formats to be used with the posts. */
-            false, // 'post-formats',
-        ),
-
-        /**
-         * Labels used when displaying the posts in the admin and sometimes on the front end.  These
-         * labels do not cover post updated, error, and related messages.  You'll need to filter the
-         * 'post_updated_messages' hook to customize those.
-         */
-        'labels'              => array(
-            'name'               => __('Regional pages', 'Clarity'),
-            'singular_name'      => __('Regional pages', 'Clarity'),
-            'menu_name'          => __('Regional pages', 'Clarity'),
-            'name_admin_bar'     => __('Pages', 'Clarity'),
-            'add_new'            => __('Add New', 'Clarity'),
-            'add_new_item'       => __('Add New page', 'Clarity'),
-            'edit_item'          => __('Edit page', 'Clarity'),
-            'new_item'           => __('New page', 'Clarity'),
-            'view_item'          => __('View regional page', 'Clarity'),
-            'search_items'       => __('Search pages', 'Clarity'),
-            'not_found'          => __('No pages found', 'Clarity'),
+            'revisions',
+            'page-attributes'
+        ],
+        'labels' => [
+            'name' => __('Regional pages', 'Clarity'),
+            'singular_name' => __('Regional pages', 'Clarity'),
+            'menu_name' => __('Regional pages', 'Clarity'),
+            'name_admin_bar' => __('Pages', 'Clarity'),
+            'add_new' => __('Add New', 'Clarity'),
+            'add_new_item' => __('Add New page', 'Clarity'),
+            'edit_item' => __('Edit page', 'Clarity'),
+            'new_item' => __('New page', 'Clarity'),
+            'view_item' => __('View regional page', 'Clarity'),
+            'search_items' => __('Search pages', 'Clarity'),
+            'not_found' => __('No pages found', 'Clarity'),
             'not_found_in_trash' => __('No pages found in trash', 'Clarity'),
-            'all_items'          => __('All pages', 'Clarity'),
-
-            /* Labels for hierarchical post types only. */
-            'parent_item'        => __('Parent Page', 'Clarity'),
-            'parent_item_colon'  => __('Parent Page:', 'Clarity'),
-
-            /* Custom archive label.  Must filter 'post_type_archive_title' to use. */
-            'archive_title'      => __('Pages', 'Clarity'),
-        ),
-    );
+            'all_items' => __('All pages', 'Clarity'),
+            'parent_item' => __('Parent Page', 'Clarity'),
+            'parent_item_colon' => __('Parent Page:', 'Clarity'),
+            'archive_title' => __('Pages', 'Clarity')
+        ],
+    ];
 
     /* Register the post type. */
     register_post_type(
         'regional_page', // Post type name. Max of 20 characters. Uppercase and spaces not allowed.
-        $args      // Arguments for post type.
+        $args // Arguments for post type.
     );
 }

--- a/web/app/themes/clarity/src/components/c-breadcrumbs/view-region-single.php
+++ b/web/app/themes/clarity/src/components/c-breadcrumbs/view-region-single.php
@@ -1,40 +1,56 @@
 <?php
-// Get the correct region name
-$post_id   = get_the_ID();
-$region_id = get_the_terms($post_id, 'region');
 
-// Loop through using the region id and get current region name
-if ($region_id) :
-    foreach ($region_id as $region) :
-        $current_region = $region->name;
-    endforeach;
-endif;
+$post_id = get_the_ID();
 
-$current_region_url_formated  = strtolower(preg_replace('#[ -]+#', '-', $current_region));
-$current_region_name_formated = ucwords($current_region);
+// Beware: HMCTS editors use the tabbed template to display regions
+// ~ support isolated long-tail, tabbed region pages, without parents
+$pre_breadcrumb_path = '';
+if (has_post_parent($post_id)) {
+    // Get the correct region name
+    $region_id = get_the_terms($post_id, 'region');
+
+    // Loop through using the region id and get current region name
+    $current_region = '';
+    if ($region_id) :
+        foreach ($region_id as $region) :
+            $current_region = $region->name;
+        endforeach;
+    endif;
+
+    $current_region_url_formatted = sanitize_text_field(
+        strtolower(
+            str_replace([' ', '&amp;', '&'], ['-', 'and'], $current_region)
+        )
+    );
+
+    $current_region_name_formatted = sanitize_text_field(ucwords($current_region));
+
+    $pre_breadcrumb_path = '<li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">
+        <a href="/regional-pages/' . $current_region_url_formatted . '">
+            <span>' . $current_region_name_formatted . '</span>
+        </a>
+    </li>';
+}
+
 ?>
 
 <!-- c-breadcrumbs (view-region-single) starts here -->
 <section class="c-breadcrumbs">
-  <ol class="c-breadcrumbs__list">
-    <li class="c-breadcrumbs__list-item">
-      <a title="Go home" href="<?php echo get_home_url(); ?>" class="home">
-        <span>Home</span>
-      </a>
-    </li> 
-    <li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">
-      <a href="/regional-pages/">
-        <span>Regions</span>
-      </a>
-    </li>
-    <li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">
-      <a href="/regional-pages/<?php echo sanitize_text_field($current_region_url_formated); ?>">
-        <span><?php echo sanitize_text_field($current_region_name_formated); ?></span>
-      </a>
-    </li>
-    <li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">
-      <span><?php the_title(); ?></span>
-    </li>
-  </ol>    
+    <ol class="c-breadcrumbs__list">
+        <li class="c-breadcrumbs__list-item">
+            <a title="Go home" href="<?php echo get_home_url(); ?>" class="home">
+                <span>Home</span>
+            </a>
+        </li>
+        <li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">
+            <a href="/regional-pages/">
+                <span>Regions</span>
+            </a>
+        </li>
+        <?= $pre_breadcrumb_path ?>
+        <li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">
+            <span><?php the_title(); ?></span>
+        </li>
+    </ol>
 </section>
 <!-- c-breadcrumbs (view-region-single) ends here -->

--- a/web/app/themes/clarity/src/components/c-breadcrumbs/view-region.php
+++ b/web/app/themes/clarity/src/components/c-breadcrumbs/view-region.php
@@ -5,49 +5,47 @@
 * hierarchy from homepage (news, event, blog singles)
 */
 
-function get_breadcrumb()
+function get_breadcrumb(): string
 {
-
     global $post;
 
-    $trail      = '';
-    $page_title = get_the_title($post->ID);
+    $trail = '';
+    $breadcrumbs = [];
 
     if ($post->post_parent) {
         $parent_id = $post->post_parent;
 
         while ($parent_id) {
-            $page          = get_page($parent_id);
-            $breadcrumbs[] = '<li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated"><a href="' . get_the_permalink($page->ID) . '">' . get_the_title($page->ID) . '</a></li>';
-            $parent_id     = $page->post_parent;
+            $page = get_post($parent_id);
+            $breadcrumbs[] = '<li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">
+                <a href="' . get_the_permalink($page->ID) . '">' . get_the_title($page->ID) . '</a>
+            </li>';
+
+            $parent_id = $page->post_parent;
         }
 
-        $breadcrumbs = array_reverse($breadcrumbs);
-        foreach ($breadcrumbs as $crumb) {
-            $trail .= $crumb;
-        }
+        $trail = implode('', array_reverse($breadcrumbs));
     }
 
-    $trail .= '<li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">' . $page_title . "</li>";
-
-    return $trail;
+    return $trail . '<li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">' . get_the_title($post->ID) . "</li>";
 }
+
 ?>
 
-  <!-- c-breadcrumbs starts here -->
-  <section class="c-breadcrumbs">
+<!-- c-breadcrumbs [region] starts here -->
+<section class="c-breadcrumbs">
     <ol class="c-breadcrumbs__list">
-      <li class="c-breadcrumbs__list-item">
-        <a title="Go home." href="<?php echo get_home_url(); ?>" class="home">
-          <span>Home</span>
-        </a>
-      </li>  
-      <li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">
-        <a href="/regional-pages/">
-          <span>Regions</span>
-        </a>
-      </li>
-      <?php echo get_breadcrumb(); ?>
+        <li class="c-breadcrumbs__list-item">
+            <a title="Go home." href="<?php echo get_home_url(); ?>" class="home">
+                <span>Home</span>
+            </a>
+        </li>
+        <li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">
+            <a href="/regional-pages/">
+                <span>Regions</span>
+            </a>
+        </li>
+        <?php echo get_breadcrumb(); ?>
     </ol>
-  </section>
-  <!-- c-breadcrumbs ends here -->
+</section>
+<!-- c-breadcrumbs ends here -->

--- a/web/app/themes/clarity/src/components/c-breadcrumbs/view.php
+++ b/web/app/themes/clarity/src/components/c-breadcrumbs/view.php
@@ -5,44 +5,42 @@
 * hierarchy from homepage (news, event, blog singles)
 */
 
-function get_breadcrumb()
+function get_breadcrumb(): string
 {
-
     global $post;
 
-    $trail      = '';
-    $page_title = get_the_title($post->ID);
+    $trail = '';
+    $breadcrumbs = [];
 
     if ($post->post_parent) {
         $parent_id = $post->post_parent;
 
         while ($parent_id) {
-            $page          = get_page($parent_id);
-            $breadcrumbs[] = ' <li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated"><a href="' . get_the_permalink($page->ID) . '">' . get_the_title($page->ID) . '</a></li>';
-            $parent_id     = $page->post_parent;
+            $page = get_post($parent_id);
+            $breadcrumbs[] = '<li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">
+                <a href="' . get_the_permalink($page->ID) . '">' . get_the_title($page->ID) . '</a>
+            </li>';
+
+            $parent_id = $page->post_parent;
         }
 
-        $breadcrumbs = array_reverse($breadcrumbs);
-        foreach ($breadcrumbs as $crumb) {
-            $trail .= $crumb;
-        }
+        $trail = implode('', array_reverse($breadcrumbs));
     }
 
-    $trail .= '<li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">' . $page_title . "</li>";
-              
-    return $trail;
+    return $trail . '<li class="c-breadcrumbs__list-item c-breadcrumbs__list-item--separated">' . get_the_title($post->ID) . "</li>";
 }
+
 ?>
 
-  <!-- c-breadcrumbs starts here -->
-  <section class="c-breadcrumbs">
+<!-- c-breadcrumbs starts here -->
+<section class="c-breadcrumbs">
     <ol class="c-breadcrumbs__list">
-      <li class="c-breadcrumbs__list-item">
-        <a title="Go home." href="<?php echo get_home_url(); ?>" class="home">
-          <span>Home</span>
-        </a>           
-      </li>
-      <?php echo get_breadcrumb(); ?>
+        <li class="c-breadcrumbs__list-item">
+            <a title="Go home." href="<?php echo get_home_url(); ?>" class="home">
+                <span>Home</span>
+            </a>
+        </li>
+        <?= get_breadcrumb() ?>
     </ol>
-  </section>
-  <!-- c-breadcrumbs ends here -->
+</section>
+<!-- c-breadcrumbs ends here -->

--- a/web/app/themes/clarity/src/components/c-tabbed-content/style.styl
+++ b/web/app/themes/clarity/src/components/c-tabbed-content/style.styl
@@ -2,66 +2,74 @@
 @require "../../globals/css/_toolkit"
 
 .c-tabbed-content {
-  &__nav {
-    width: 100%;
-    border-bottom: 1px solid $border;
-    margin-bottom: $spacing;
-    li {
-      padding: $spacing;
-      background: $boxBg;
-      border: 1px solid $border;
-      cursor: pointer;
-      text-transform: capitalize;
-      font-size: $outerCore;
-      color: $links;
-      margin-bottom -1px;
-      +above(m) {
-        display: inline-block
-        width: 33.3%;
-        border: 3px solid $light;
-        border-bottom: 0;
-      }
+    &__nav {
+        width: 100%;
+        border-bottom: 1px solid $border;
+        margin-bottom: $spacing;
+        display: flex;
+        flex-wrap: wrap;
 
-      &:not(.u-current):hover {
-        background-color: darken($boxBg, 2%)
-      }
-      &:focus,
-      &.u-current:focus{  
-        background-color: #ffbf47;
-        color: #0b0c0c;
-        outline: none;
-        position: relative;
-        &:after{
-          content: "";
-          position: absolute;
-          bottom: 0;
-          left: 0;
-          width: 100%;
-          height: 5px;
-          background-color: #0b0c0c;
+        li {
+            padding: $spacing;
+            background: $boxBg;
+            border: 1px solid $border;
+            cursor: pointer;
+            text-transform: capitalize;
+            font-size: $outerCore;
+            color: $links;
+            margin-bottom -1px;
+            +above(m) {
+                display: inline-block
+                width: 33.3%;
+                border: 3px solid $light;
+                border-bottom: 0;
+            }
+
+            &:not(.u-current):hover {
+                background-color: darken($boxBg, 2%)
+            }
+
+            &:focus,
+            &.u-current:focus {
+                background-color: #ffbf47;
+                color: #0b0c0c;
+                outline: none;
+                position: relative;
+
+                &:after {
+                    content: "";
+                    position: absolute;
+                    bottom: 0;
+                    left: 0;
+                    width: 100%;
+                    height: 5px;
+                    background-color: #0b0c0c;
+                }
+            }
+
+            &.u-current {
+                color: $dark;
+                +above(m) {
+                    border: 1px solid $border;
+                    border-bottom: 1px solid $light;
+
+                }
+
+                background-color: $light;
+            }
         }
-      }
-      &.u-current {
-        color: $dark;
-        +above(m) {
-          border: 1px solid $border;
-          border-bottom: 1px solid $light;
+    }
 
+    &.u-current {
+        display: block;
+    }
+
+    /.js & {
+        display: none;
+
+        > h1 {
+            display: none;
         }
-
-        background-color: $light;
-      }
     }
-  }
-  &.u-current {
-    display:block;
-  }
-   /.js & {
-    display:none;
-
-    > h1 {
-      display: none;
-    }
-  }
 
 }


### PR DESCRIPTION
This PR has a couple of treats:

1. Selectively drops a longer path in the breadcrumb, if needed
2. High-level code refactoring in a breadcrumb function
3. Flexbox has been added to tabs to assist in a clearer display for the user

## Before
* The breadcrumb was repeated
* Tabs looking displaced

![Screenshot 2023-07-03 at 17 23 56](https://github.com/ministryofjustice/intranet/assets/47327051/4d4053d4-3a3b-42e5-9d76-16f9b1f1e020)

---

## After
![Screenshot 2023-07-03 at 17 26 38](https://github.com/ministryofjustice/intranet/assets/47327051/2bb2c340-e009-49df-8268-0c229399ae1d)

