### PR TITLE
CDPT-903 Fix TypeError array_shift()

### DIFF
--- a/web/app/themes/clarity/inc/admin/agency_taxonomies/taxonomies/agency.php
+++ b/web/app/themes/clarity/inc/admin/agency_taxonomies/taxonomies/agency.php
@@ -192,20 +192,24 @@ class Agency extends Taxonomy
      *
      * @param int $user_id The ID of the user to save the terms for.
      */
-    public function edit_user_profile_save($user_id)
+    public function edit_user_profile_save(int $user_id): void
     {
+        // Get the chosen agency value selected from the radio button
+        $selectedAgency = $_POST['agency'] ?? Agency_Context::get_agency_context();
 
-        // Get the chosen agency value selected from the ratio button
-        $selectedAgency = isset($_POST['agency']) ? $_POST['agency'] : 'hq';
+        // if selected, result is array, otherwise it's a string
+        if (is_array($selectedAgency)) {
+            $selectedAgency = array_shift($selectedAgency);
+        }
 
         // Sanitize POST value and select chosen agency from array
-        $newAgency = sanitize_text_field(array_shift($selectedAgency));
+        $newAgency = sanitize_text_field($selectedAgency);
 
         // Update the user's agency context
         update_user_meta($user_id, 'agency_context', $newAgency);
 
         // Set the terms for the user so their choice stays chosen in radio box
-        wp_set_object_terms($user_id, $newAgency, 'agency', false);
+        wp_set_object_terms($user_id, $newAgency, 'agency');
         clean_object_term_cache($user_id, 'agency');
     }
 
@@ -294,7 +298,7 @@ class Agency extends Taxonomy
     }
 
 
-        /**
+    /**
      * Stop users from editing posts that belong to agencies which are not
      * the current agency context.
      *
@@ -368,6 +372,9 @@ class Agency extends Taxonomy
         return $actions;
     }
 
+    /**
+     * @return false|void
+     */
     public function quick_action_opt_in_out()
     {
         if (


### PR DESCRIPTION
**_Context_**
This error occurs when a user is created or edited without a default agency being chosen. The code always expects an array to be passed; this is highly opinionated and isn't always true. The default 'hq' agency is given as a string when an agency has not been selected. 

The error this behaviour gives is fatal. It is destructive because the user's journey is halted immediately, and no reason is given to explain what happened.

**_The Fix_**
We assess an array and treat it accordingly. The code expects a string result on line 206 regardless of the origin type. In addition, it is assumed that the new or edited user should be created under the current context. Currently, a user is given HQ status if an agency isn't chosen. This release defaults the user to the current agency if one has not been selected.