### PR TITLE
CDPT-916 : document fix script - written as a command

### DIFF
--- a/web/app/themes/clarity/functions.php
+++ b/web/app/themes/clarity/functions.php
@@ -11,7 +11,7 @@
  */
 
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
-    require_once 'inc/commands/NotesFromAntonia.php';
+    require_once 'inc/commands/DocumentRevisionReconcile.php';
 }
 
 require_once 'inc/admin/acf-field-group.php';

--- a/web/app/themes/clarity/inc/admin/css/admin.css
+++ b/web/app/themes/clarity/inc/admin/css/admin.css
@@ -6,3 +6,4 @@
 */
 @import "page-search-dropdown-filter.css";
 @import "acf-homepage-feature.css";
+@import "hide-document-revision-description-box.css";

--- a/web/app/themes/clarity/inc/admin/css/hide-document-revision-description-box.css
+++ b/web/app/themes/clarity/inc/admin/css/hide-document-revision-description-box.css
@@ -1,0 +1,4 @@
+.post-type-document #post-body-content h2,
+.post-type-document #postdivrich {
+    display: none !important;
+}

--- a/web/app/themes/clarity/inc/commands/DocumentRevisionReconcile.php
+++ b/web/app/themes/clarity/inc/commands/DocumentRevisionReconcile.php
@@ -1,0 +1,223 @@
+<?php
+/**
+ * Usage:
+ *  dry-run: wp fix-document-revisions
+ *  real-run: wp fix-document-revisions fix-documents
+ */
+
+class DocumentRevisionReconcile
+{
+    /**
+     * @var array
+     */
+    public array $posts;
+
+    /**
+     * @var wpdb|QM_DB
+     */
+    public wpdb|QM_DB $db;
+
+    /**
+     * @var false
+     */
+    private bool $dry_run;
+
+    private array $reportable;
+
+    private array $succeeded;
+
+    public function __construct()
+    {
+        global $wpdb;
+
+        $this->db = $wpdb;
+        $this->dry_run = true;
+    }
+
+    public function __invoke($args): void
+    {
+        error_reporting(0);
+
+        $do_fix = $args[0] ?? '';
+
+        if ($do_fix === 'fix-documents') {
+            $this->dry_run = false;
+        }
+
+        $this->active();
+    }
+
+    private function active(): void
+    {
+        $this->warning();
+        $this->prepare();
+        $this->collect();
+        $this->update();
+        $this->report();
+    }
+
+    private function prepare(): void
+    {
+        $query = 'SELECT `ID`, `post_title`
+                    FROM `wp_posts`
+                    WHERE `post_type` LIKE \'document\'
+                        AND `post_content` LIKE \'\'
+                        AND `post_status` LIKE \'publish\'';
+
+        $this->posts = $this->db->get_results($query);
+        $this->message(['%d broken documents were found.' => count($this->posts)]);
+    }
+
+    private function collect(): void
+    {
+        $counter = 0;
+        foreach ($this->posts as $key => $post) {
+            $parent_id = $this->db->get_var("SELECT ID FROM `wp_posts` WHERE `post_parent` = $post->ID AND `post_type` LIKE 'attachment'");
+            if (is_numeric($parent_id)) {
+                $this->posts[$key]->attachment = $parent_id;
+                $counter++;
+            }
+        }
+
+        $this->message(['%d documents have stray revisions.' => $counter]);
+    }
+
+    private function update(): void
+    {
+        foreach ($this->posts as $key => $post) {
+            // let's check the attachment property
+            $attachment_is_set = false;
+            if (property_exists($post, 'attachment') && is_numeric($post->attachment)) {
+                $attachment_is_set = true;
+            }
+
+            if ($this->dry_run === false) {
+                $result = 0;
+                if ($attachment_is_set) {
+                    // run the update
+                    $result = $this->db->update(
+                        'wp_posts',
+                        ['post_content' => '<!-- WPDR ' . $post->attachment . ' -->'],
+                        ['ID' => $post->ID]
+                    );
+                }
+
+                if ($result === 1) {
+                    $this->succeeded($post);
+                    $this->message(['Update succeeded for: %s' => $post->post_title], 'success');
+                } else {
+                    $this->reportable($post);
+                    $this->message(['Update failed with ID %d' => $post->ID], 'warning');
+                }
+
+                continue;
+            }
+
+            if ($key === 0) {
+                $this->message("Dry run activated.");
+                $this->message("Checking queries...");
+            }
+
+            // what would have happened?
+            if ($attachment_is_set) {
+                $this->succeeded($post);
+                $this->message([
+                    'Update succeeded for: %s' => "UPDATE `wp_posts` SET `post_content` = '<!-- WPDR $post->attachment -->' WHERE `ID` = $post->ID"
+                ],
+                    'success'
+                );
+            } else {
+                $this->reportable($post);
+                $this->message(['Update failed with ID %d' => $post->ID], 'warning');
+            }
+        }
+    }
+
+    private function report(): void
+    {
+        if (!empty($this->reportable)) {
+            $message = "Documents have been flagged unfixable by the Intranet. We identified them in a recent attempt to fix 403 errors.\n\n";
+            $message .= "Editors created the following documents without uploading an artefact.\n\n";
+            foreach ($this->reportable as $errored) {
+                $message .= "_____________________________________\n{$errored['agency']}: {$errored['title']}\n- {$errored['admin_url']}\n\n";
+            }
+
+            $this->message($message);
+            wp_mail('damien.wilson@digital.justice.gov.uk,rhian.townsend@digital.justice.gov.uk', 'Document Revisions: unfixable', $message);
+        }
+
+        if (!empty($this->succeeded)) {
+            $message = "Documents have been successfully repaired. We identified them in a recent effort to fix 403 errors.\n\n";
+            foreach ($this->succeeded as $repaired) {
+                $message .= "_____________________________________\n{$repaired['agency']}: {$repaired['title']}\n- {$repaired['link']}\n- {$repaired['admin_url']}\n\n";
+            }
+
+            $this->message($message);
+            wp_mail('damien.wilson@digital.justice.gov.uk,rhian.townsend@digital.justice.gov.uk', 'Document Revisions: repaired', $message);
+        }
+    }
+
+    private function warning(): void
+    {
+        if (!$this->dry_run) {
+            $this->message("\nAre you sure you want to continue?", 'confirm');
+            $this->message("\n---------------------------------\n");
+            $this->message("We will attempt to fix all document revisions.\n", 'warning');
+
+            sleep(3);
+
+            $this->message("\n---------------------------------\n");
+            $this->message("Beginning repair effort now...");
+        }
+    }
+
+    private function succeeded($post): void
+    {
+        $this->succeeded['moj_' . $post->ID] = [
+            'link' => get_the_permalink($post->ID),
+            'title' => $post->post_title,
+            'admin_url' => get_admin_url($post->ID) . "post.php?post=$post->ID&action=edit",
+            'agency' => get_the_terms($post->ID, 'agency')[0]->name
+        ];
+    }
+
+    private function reportable($post): void
+    {
+        $this->reportable['moj_' . $post->ID] = [
+            'id' => $post->ID,
+            'title' => $post->post_title,
+            'admin_url' => get_admin_url($post->ID) . "post.php?post=$post->ID&action=edit",
+            'agency' => get_the_terms($post->ID, 'agency')[0]->name
+        ];
+    }
+
+    private function message($message, $status = 'log'): void
+    {
+        if (is_array($message)) {
+            $message = sprintf(key($message), $message[key($message)]);
+        }
+
+        switch ($status) {
+            case 'confirm':
+                WP_CLI::confirm($message);
+                break;
+            case 'success':
+                WP_CLI::success($message);
+                break;
+            case 'warning':
+                WP_CLI::warning($message);
+                break;
+            case 'log':
+                WP_CLI::log($message);
+                break;
+
+        }
+    }
+}
+
+// 1. Register the instance for the callable parameter.
+$instance = new DocumentRevisionReconcile();
+WP_CLI::add_command('fix-document-revisions', $instance);
+
+// 2. Register object as a function for the callable parameter.
+WP_CLI::add_command('fix-document-revisions', 'DocumentRevisionReconcile');

--- a/web/app/themes/clarity/inc/commands/NotesFromAntonia.php
+++ b/web/app/themes/clarity/inc/commands/NotesFromAntonia.php
@@ -4,7 +4,7 @@
  *
  * Notes From Antonia is a live feature!
  * This command should not be used but instead, kept to further
- * develop into a generic long-tail page to blog converter
+ * develop into a generic 'long-tail page to blog' converter
  *
  * ------------------------------------
  *

--- a/web/app/themes/clarity/inc/commands/NotesFromAntonia.php
+++ b/web/app/themes/clarity/inc/commands/NotesFromAntonia.php
@@ -1,6 +1,13 @@
 <?php
-
 /**
+ * ------------------------------------
+ *
+ * Notes From Antonia is a live feature!
+ * This command should not be used but instead, kept to further
+ * develop into a generic long-tail page to blog converter
+ *
+ * ------------------------------------
+ *
  * Import and restructure content from the long-tail NFA page
  * Usage:
  *  dry-run: wp notes-from-antonia convert


### PR DESCRIPTION
**Context**
Stakeholders have been reporting 403 errors on document revisions. After investigation, it was discovered that users were removing the ID association from documents, which inadvertently lost the link to the attached revisions.

**This release does 2 things:**

1. Provides a command to fix lost documents
2. Hides the Document Description box on document post-type pages to deter users from removing the ID association.


## Before
![Screenshot 2023-09-06 at 20 39 18](https://github.com/ministryofjustice/intranet/assets/47327051/ea93f13b-644a-47ed-97b6-4e87fd1dc1e5)

## After
![Screenshot 2023-09-06 at 20 39 37](https://github.com/ministryofjustice/intranet/assets/47327051/94b9fcf5-355e-4357-8ab3-a344da7a9043)


