### PR TITLE
Debug helper function. Add log to file.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ ELASTICSEARCH_HOST=http://elasticsearch:9200
 # REPURPOSED: GovUK Notify - API KEY
 SMTP_PASSWORD=PLEASE-REPLACE-WITH-YOUR-OWN-DEV-API-KEY
 
+# Enable logging to file. Default: false
+# WP_DEBUG_LOG=true
+
 # Generate your keys here: https://roots.io/salts.html
 AUTH_KEY=saltykey
 SECURE_AUTH_KEY=saltykey

--- a/config/environments/development.php
+++ b/config/environments/development.php
@@ -1,8 +1,15 @@
 <?php
 /** Development */
+
+/**
+ * Expose global env() function from oscarotero/env
+ */
+Env::init();
+
 const SAVEQUERIES = true;
 const WP_DEBUG = true;
 const SCRIPT_DEBUG = true;
+define('WP_DEBUG_LOG', env('WP_DEBUG_LOG'));
 
 const SENTRY_TRACES_SAMPLE_RATE = 1.0;
 const SENTRY_PROFILE_SAMPLE_RATE = 1.0;

--- a/web/app/themes/clarity/inc/helpers/debug.php
+++ b/web/app/themes/clarity/inc/helpers/debug.php
@@ -6,6 +6,7 @@
  * Debug::full($var) - shows the structure of $variable, recurses objects
  * Debug::raw($var) - does print_r($var)
  * Debug::pre($var) - does print_r($var) wrapped in <pre></pre>
+ * Debug::log($var) - wirtes print_r($var) to file. Requires WP_DEBUG_LOG=true. Watch with `tail -f /bedrock/web/app/debug.log`
  */
 class Debug
 {
@@ -37,6 +38,15 @@ class Debug
     public static function full($var, $maxlevel = 5)
     {
         self::debug_var($var, true, $maxlevel);
+    }
+
+    public static function log($var)
+    {
+        if (is_array($var) || is_object($var)) {
+            error_log(print_r($var, true));
+         } else {
+            error_log($var);
+         }
     }
 
     private static function debug_var($var, $recurseObjects = false, $maxlevel = 5)

--- a/web/app/themes/clarity/inc/helpers/debug.php
+++ b/web/app/themes/clarity/inc/helpers/debug.php
@@ -6,7 +6,7 @@
  * Debug::full($var) - shows the structure of $variable, recurses objects
  * Debug::raw($var) - does print_r($var)
  * Debug::pre($var) - does print_r($var) wrapped in <pre></pre>
- * Debug::log($var) - wirtes print_r($var) to file. Requires WP_DEBUG_LOG=true. Watch with `tail -f /bedrock/web/app/debug.log`
+ * Debug::log($var) - if WP_DEBUG_LOG=true print_r($var) is written to file, else, the message will stout.
  */
 class Debug
 {


### PR DESCRIPTION
Add Debug::log to allow for debugging when writing to a log file is more suitable than printing to the page.