### PR TITLE
cloudfront-input secret for terraform. A/B public keys allows for key rotation with grace period.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,11 +40,14 @@ jobs:
           SECURE_AUTH_KEY: ${{ secrets.SECURE_AUTH_KEY }}
           SECURE_AUTH_SALT: ${{ secrets.SECURE_AUTH_SALT }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          AWS_CLOUDFRONT_PUBLIC_KEY: "${{ secrets.AWS_CLOUDFRONT_PUBLIC_KEY }}"
-          AWS_CLOUDFRONT_PRIVATE_KEY: "${{ secrets.AWS_CLOUDFRONT_PRIVATE_KEY }}"
+          AWS_CLOUDFRONT_PUBLIC_KEY: "${{ secrets.AWS_CLOUDFRONT_PUBLIC_KEY_A }}"
+          AWS_CLOUDFRONT_PRIVATE_KEY: "${{ secrets.AWS_CLOUDFRONT_PRIVATE_KEY_A }}"
+          # AWS_CLOUDFRONT_PUBLIC_KEY_EXPIRING: "${{ secrets.AWS_CLOUDFRONT_PUBLIC_KEY_B }}"
         run: |
           export AWS_CLOUDFRONT_PUBLIC_KEY_BASE64=$(echo -n "$AWS_CLOUDFRONT_PUBLIC_KEY" | base64 -w 0)
           export AWS_CLOUDFRONT_PRIVATE_KEY_BASE64=$(echo -n "$AWS_CLOUDFRONT_PRIVATE_KEY" | base64 -w 0)
+          # export AWS_CLOUDFRONT_PUBLIC_KEY_EXPIRING_BASE64=$(echo -n "$AWS_CLOUDFRONT_PUBLIC_KEY_EXPIRING" | base64 -w 0)
+
           cat $TPL_PATH/secret.tpl | envsubst > $TPL_PATH/secret.yaml
           cat $TPL_PATH/deployment.tpl | envsubst > $TPL_PATH/deployment.yaml
 

--- a/deploy/development/deployment.tpl
+++ b/deploy/development/deployment.tpl
@@ -69,7 +69,7 @@ spec:
                 secretKeyRef:
                   name: cloudfront-output
                   key: cloudfront_url
-            - name: AWS_CLOUDFRONT_PUBLIC_KEY_OBJECT
+            - name: AWS_CLOUDFRONT_PUBLIC_KEYS_OBJECT
               valueFrom:
                 secretKeyRef:
                   name: cloudfront-output

--- a/deploy/development/secret.tpl
+++ b/deploy/development/secret.tpl
@@ -22,5 +22,13 @@ metadata:
   name: intranet-dev-base64-secrets
 type: Opaque
 data:
-  AWS_CLOUDFRONT_PUBLIC_KEY: "${AWS_CLOUDFRONT_PUBLIC_KEY_BASE64}"
   AWS_CLOUDFRONT_PRIVATE_KEY: "${AWS_CLOUDFRONT_PRIVATE_KEY_BASE64}"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudfront-input
+type: Opaque
+data:
+  AWS_CLOUDFRONT_PUBLIC_KEY: "${AWS_CLOUDFRONT_PUBLIC_KEY_BASE64}"
+  # AWS_CLOUDFRONT_PUBLIC_KEY_EXPIRING: "${AWS_CLOUDFRONT_PUBLIC_KEY_EXPIRING_BASE64}"

--- a/public/app/themes/clarity/inc/amazon-s3-and-cloudfront-signing.php
+++ b/public/app/themes/clarity/inc/amazon-s3-and-cloudfront-signing.php
@@ -130,7 +130,7 @@ class AmazonS3AndCloudFrontSigning
 
         // If the public key is not found, throw an exception.
         if (empty($public_key_ids_and_keys)) {
-            throw new \Exception('AWS_CLOUDFRONT_PUBLIC_KEY_OBJECT was not found');
+            throw new \Exception('AWS_CLOUDFRONT_PUBLIC_KEYS_OBJECT was not found');
         }
 
         // Find the matching array entry for the public key.


### PR DESCRIPTION
This PR creates a `cloudfront-input` secret.

That means that we don't need to have our trusted public keys hardcoded in out `cloudfront.tf` file.

A change to `deploy.yaml` will allow us to rotate the trusted public keys with a grace period. Meaning that during key rotation we do not need to update the PEM values in our app and CloudFront at exactly the same instant. And, visitors with recently signed cookies will still have access to assets for a short while.

There are also a couple of typo fixes.