### PR TITLE
CDPT-1773 - Prior party banner add comments, end date inclusive.

### DIFF
--- a/web/app/themes/clarity/acf-json/group_667d8381383f1.json
+++ b/web/app/themes/clarity/acf-json/group_667d8381383f1.json
@@ -31,7 +31,7 @@
                     "name": "banner_content",
                     "aria-label": "",
                     "type": "textarea",
-                    "instructions": "The text that will be shown in Prior Party Banner.\r\ne.g. This was published under the 2015 to 2024 Conservative government",
+                    "instructions": "The text that will be shown in Prior Party Banner.<br\/><br\/>\r\ne.g. This was published under the 2015 to 2024 Conservative government",
                     "required": 1,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -53,7 +53,7 @@
                     "name": "start_date",
                     "aria-label": "",
                     "type": "date_picker",
-                    "instructions": "The start date of the party's government.",
+                    "instructions": "The start date of the party's government.<br\/><br\/>\r\nWhen looking up which banner to use, a post's publish date will be compared to 00:00:00 on this date.",
                     "required": 1,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -73,7 +73,7 @@
                     "name": "end_date",
                     "aria-label": "",
                     "type": "date_picker",
-                    "instructions": "The end date of the party's government.",
+                    "instructions": "The end date of the party's government.<br\/><br\/>\r\nWhen looking up which banner to use, a post's publish date will be compared to 23:59:59 on this date.",
                     "required": 1,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -152,5 +152,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1720166982
+    "modified": 1720434982
 }

--- a/web/app/themes/clarity/acf-json/group_667d8381383f1.json
+++ b/web/app/themes/clarity/acf-json/group_667d8381383f1.json
@@ -53,7 +53,7 @@
                     "name": "start_date",
                     "aria-label": "",
                     "type": "date_picker",
-                    "instructions": "The start date of the party's government.<br\/><br\/>\r\nWhen looking up which banner to use, a post's publish date will be compared to 00:00:00 on this date.",
+                    "instructions": "The start date of the party's government.<br\/><br\/>\r\nWhen looking up which banner to use, a post's publish date must be >= 00:00:00 on this date.",
                     "required": 1,
                     "conditional_logic": 0,
                     "wrapper": {
@@ -73,7 +73,7 @@
                     "name": "end_date",
                     "aria-label": "",
                     "type": "date_picker",
-                    "instructions": "The end date of the party's government.<br\/><br\/>\r\nWhen looking up which banner to use, a post's publish date will be compared to 23:59:59 on this date.",
+                    "instructions": "The end date of the party's government.<br\/><br\/>\r\nWhen looking up which banner to use, a post's publish date must be < 00:00:00 on the following date.",
                     "required": 1,
                     "conditional_logic": 0,
                     "wrapper": {

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
@@ -262,7 +262,7 @@ class PriorPartyBannerAdmin
 
                     // links
                     $link_admin = get_edit_post_link($post->ID);
-                    $link_view = get_permalink($post->ID) . '?show-inactive' . $link_view_suffix;
+                    $link_view = get_permalink($post->ID) . '?show_inactive' . $link_view_suffix;
 
                     // latest event
                     $event_data = $this->getTrackedDisplayString($post->ID);

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
@@ -213,7 +213,7 @@ class PriorPartyBannerAdmin
 
             // If the end date has not passed... for previewing we need to set a time context after the end date.
             // i.e. exactly 00:00:00 the next day.
-            $link_view_suffix = $stop > new \DateTime() ? '?time_context=' . $stop->modify('+1 day')->format('U') : '';
+            $link_view_suffix = $stop > new \DateTime() ? '&time_context=' . $stop->modify('+1 day')->format('U') : '';
 
             // display the banner
             echo '<div class="prior-party-banner">
@@ -262,7 +262,7 @@ class PriorPartyBannerAdmin
 
                     // links
                     $link_admin = get_edit_post_link($post->ID);
-                    $link_view = get_permalink($post->ID) . $link_view_suffix;
+                    $link_view = get_permalink($post->ID) . '?show-inactive' . $link_view_suffix;
 
                     // latest event
                     $event_data = $this->getTrackedDisplayString($post->ID);

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
@@ -211,9 +211,19 @@ class PriorPartyBannerAdmin
             $start = new \DateTime($this->banner["start_date"]);
             $stop = new \DateTime($this->banner["end_date"]);
 
+
+            // Init an array to hold the query string for viewing the banner.
+            $link_view_queries = [];
+            // If the banner is inactive, we need to set a query string to show it.
+            if(!$this->banner['banner_active']) {
+                $link_view_queries['show_inactive'] = '';
+            }
+
             // If the end date has not passed... for previewing we need to set a time context after the end date.
             // i.e. exactly 00:00:00 the next day.
-            $link_view_suffix = $stop > new \DateTime() ? '&time_context=' . $stop->modify('+1 day')->format('U') : '';
+            if($stop > new \DateTime()) {
+                $link_view_queries['time_context'] = $stop->modify('+1 day')->format('U');
+            }
 
             // display the banner
             echo '<div class="prior-party-banner">
@@ -262,7 +272,7 @@ class PriorPartyBannerAdmin
 
                     // links
                     $link_admin = get_edit_post_link($post->ID);
-                    $link_view = get_permalink($post->ID) . '?show_inactive' . $link_view_suffix;
+                    $link_view = get_permalink($post->ID) . '?' . http_build_query($link_view_queries);
 
                     // latest event
                     $event_data = $this->getTrackedDisplayString($post->ID);

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
@@ -216,7 +216,7 @@ class PriorPartyBannerAdmin
             $link_view_queries = [];
             // If the banner is inactive, we need to set a query string to show it.
             if(!$this->banner['banner_active']) {
-                $link_view_queries['show_inactive'] = '';
+                $link_view_queries['preview_unpublished'] = '';
             }
 
             // If the end date has not passed... for previewing we need to set a time context after the end date.
@@ -272,6 +272,7 @@ class PriorPartyBannerAdmin
 
                     // links
                     $link_admin = get_edit_post_link($post->ID);
+                    // The query string can be 0, 1, or 2 of: `preview_unpublished`, `time_context`.
                     $link_view = get_permalink($post->ID) . '?' . http_build_query($link_view_queries);
 
                     // latest event

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
@@ -211,6 +211,9 @@ class PriorPartyBannerAdmin
             $start = new \DateTime($this->banner["start_date"]);
             $stop = new \DateTime($this->banner["end_date"]);
 
+            // If the end date has not passed... for previewing we need to set a time context after the end date.
+            // i.e. exactly 00:00:00 the next day.
+            $link_view_suffix = $stop > new \DateTime() ? '?time_context=' . $stop->modify('+1 day')->format('U') : '';
 
             // display the banner
             echo '<div class="prior-party-banner">
@@ -259,7 +262,7 @@ class PriorPartyBannerAdmin
 
                     // links
                     $link_admin = get_edit_post_link($post->ID);
-                    $link_view = get_permalink($post->ID) . '?time_context=' . $stop->format('U');
+                    $link_view = get_permalink($post->ID) . $link_view_suffix;
 
                     // latest event
                     $event_data = $this->getTrackedDisplayString($post->ID);

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
@@ -168,9 +168,9 @@ class PriorPartyBanner
         $active_banners = array_filter(
             $mapped_banners,
             function ($banner) {
-                // If show_inactive is in the query string & the user can edit posts... they can see banners regardless of banner_active state.
+                // If preview_unpublished is in the query string & the user can edit posts... they can see banners regardless of banner_active state.
                 // Else, other users (and logged out visitors) are only shown banners that are active.
-                $user_can_view = (isset($_GET['show_inactive']) && current_user_can('edit_posts')) || $banner['banner_active'] === true;
+                $user_can_view = (isset($_GET['preview_unpublished']) && current_user_can('edit_posts')) || $banner['banner_active'] === true;
 
                 return $user_can_view && $banner['end_epoch'] && ($banner['end_epoch'] <= $this->time_context);
             }

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
@@ -81,10 +81,17 @@ class PriorPartyBanner
     }
 
     /**
-     * Get the preview time from the query string.
+     * Get the time context from the query string.
      * 
-     * Validates the time_context query var against known end epochs.
-     * Returns false if if: 
+     * Why do we need a time context?
+     * Under normal circumstances, the banner will only show if the current date is between the start and end dates.
+     * This makes sense in the context of *Prior* Party Banners. We don't want to show a banner for a government that hasn't left yet.
+     * ...
+     * However, to preview a banner that hasn't ended yet, we need to set the time context to the day after the banner ends.
+     * In effect we are time travelling the user into the future, the day after a banner's end date, so that they can see the banner.
+     * 
+     * This function validates the time_context query var against known end epochs.
+     * Returns false if: 
      * - the user is not logged in or can't edit posts
      * - the value not in the known array
      * - or the time_context is in the past
@@ -94,7 +101,7 @@ class PriorPartyBanner
      * @return false|int
      */
 
-    public function getPreviewTime(array $known_end_epochs): false | int
+    public function getTimeContext(array $known_end_epochs): false | int
     {
         // Is the user logged in and can edit posts?
         if (!current_user_can('edit_posts')) {
@@ -158,7 +165,7 @@ class PriorPartyBanner
         );
 
         // Set the current timestamp.
-        $preview_time = $this->getPreviewTime($known_end_epochs);
+        $preview_time = $this->getTimeContext($known_end_epochs);
         // Time context will either be:
         // - 00:00:00 the day after a banner that hasn't ended yet
         // - or now

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
@@ -59,6 +59,9 @@ class PriorPartyBanner
 
         // Filter the instructions on the edit post screen.
         add_filter('acf/load_field/key=' . $this->page_field_key, [$this, 'modifyFieldInstructions']);
+
+        // Filter the content.
+        add_filter('the_content', [$this, 'filterRichTextContent'], 15);
     }
 
     public function init(): void
@@ -107,7 +110,7 @@ class PriorPartyBanner
         }
 
         // Return false if the time_context is in the past - it's unnecessary.
-        if((int) $_GET['time_context'] < time()) {
+        if ((int) $_GET['time_context'] < time()) {
             return false;
         }
 
@@ -378,7 +381,25 @@ class PriorPartyBanner
         }
 
         // We have a banner to display.
+        ob_start();
         get_template_part('src/components/c-notification-banner/view', null, ['heading' => $banner['banner_content']]);
+        return ob_get_clean();
+    }
+
+    /**
+     * If a shortcode has been applied, then the banner will be inside a p tag. Remove the opening and closing p tags.
+     * 
+     * @param string $content
+     * 
+     * @return string
+     */
+
+    public function filterRichTextContent(string $content): string
+    {
+        $content = preg_replace('/<p>\s*(<!-- c-moj-banner starts here -->)/', '$1', $content);
+        $content = preg_replace('/(<!-- c-moj-banner ends here -->)\s*<\/p>/', '$1', $content);
+
+        return $content;
     }
 
     /**

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
@@ -167,7 +167,13 @@ class PriorPartyBanner
         // Only include active banners where the end date is in the past.
         $active_banners = array_filter(
             $mapped_banners,
-            fn ($banner) => ($banner['banner_active'] === true && $banner['end_epoch']) && ($banner['end_epoch'] <= $this->time_context)
+            function ($banner) {
+                // If the user can edit posts then they can see all banners regardless of banner_active state.
+                // Else, other users (and logged out visitors) are only show banners that are active.
+                $user_can_view = current_user_can('edit_posts') || $banner['banner_active'] === true;
+
+                return ($user_can_view && $banner['end_epoch']) && ($banner['end_epoch'] <= $this->time_context);
+            } 
         );
 
         $this->banners = $active_banners;

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
@@ -59,9 +59,6 @@ class PriorPartyBanner
 
         // Filter the instructions on the edit post screen.
         add_filter('acf/load_field/key=' . $this->page_field_key, [$this, 'modifyFieldInstructions']);
-
-        // Filter the content.
-        add_filter('the_content', [$this, 'filterRichTextContent'], 15);
     }
 
     public function init(): void
@@ -379,6 +376,9 @@ class PriorPartyBanner
         if (!$banner) {
             return;
         }
+
+        // Filter the content to remove the p tags that are added before and after the shortcode.
+        add_filter('the_content', [$this, 'filterRichTextContent'], 15);
 
         // We have a banner to display.
         ob_start();

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
@@ -32,7 +32,7 @@ class PriorPartyBanner
     /**
      * @var string defines the key of the ACF field for the on/off toggle
      */
-    private string $page_field_group_key = 'field_667d8a0fd14f1';
+    private string $page_field_key = 'field_667d8a0fd14f1';
 
     /**
      * @var string defines the name of the ACF field on the posts
@@ -58,7 +58,7 @@ class PriorPartyBanner
         add_shortcode('prior-party-banner', [$this, 'renderBannerShortcode']);
 
         // Filter the instructions on the edit post screen.
-        add_filter('acf/load_field/key=' . $this->page_field_group_key, [$this, 'modifyFieldInstructions']);
+        add_filter('acf/load_field/key=' . $this->page_field_key, [$this, 'modifyFieldInstructions']);
     }
 
     public function init(): void
@@ -80,6 +80,20 @@ class PriorPartyBanner
         $this->loadBanners();
     }
 
+    /**
+     * Get the preview time from the query string.
+     * 
+     * Validates the time_context query var against known end epochs.
+     * Returns false if if: 
+     * - the user is not logged in or can't edit posts
+     * - the value not in the known array
+     * - or the time_context is in the past
+     * 
+     * @param array $known_end_epochs
+     * 
+     * @return false|int
+     */
+
     public function getPreviewTime(array $known_end_epochs): false | int
     {
         // Is the user logged in and can edit posts?
@@ -92,6 +106,11 @@ class PriorPartyBanner
             return false;
         }
 
+        // Return false if the time_context is in the past - it's unnecessary.
+        if((int) $_GET['time_context'] < time()) {
+            return false;
+        }
+
         // Compare time_context against known end_epochs.
         if (in_array($_GET['time_context'], $known_end_epochs, false)) {
             return (int) $_GET['time_context'];
@@ -99,6 +118,16 @@ class PriorPartyBanner
 
         return false;
     }
+
+
+    /**
+     * Load banners from the ACF repeater field.
+     * 
+     * This function maps the start and end dates to epoch timestamps for comparison.
+     * It also sets the time context to the current time or a preview time.
+     * 
+     * @return void
+     */
 
     public function loadBanners(): void
     {
@@ -117,7 +146,7 @@ class PriorPartyBanner
                 'banner_active' => $banner['banner_active'],
                 'banner_content' => $banner['banner_content'],
                 'start_epoch' => strtotime($banner['start_date']),
-                'end_epoch' => $banner['end_date'] ? strtotime($banner['end_date']) : null
+                'end_epoch' => $banner['end_date'] ? (new \DateTime($banner["end_date"]))->modify('+1 day')->format('U')  : null
             ],
             $all_banners
         );
@@ -130,21 +159,10 @@ class PriorPartyBanner
 
         // Set the current timestamp.
         $preview_time = $this->getPreviewTime($known_end_epochs);
+        // Time context will either be:
+        // - 00:00:00 the day after a banner that hasn't ended yet
+        // - or now
         $this->time_context = $preview_time ?: time();
-
-        // is this a dummy context for viewing?
-        if ($preview_time > 0) {
-            // Only include banners where the user is an editor (or beyond) and the end date is in the past.
-            $active_banners = array_filter(
-                $mapped_banners,
-                fn ($banner) => (current_user_can('edit_posts') && $banner['end_epoch']) && ($banner['end_epoch'] <= $this->time_context)
-            );
-
-            $this->banners = $active_banners;
-
-            // let's bail (void) - our work here is done
-            return;
-        }
 
         // Only include active banners where the end date is in the past.
         $active_banners = array_filter(
@@ -252,21 +270,29 @@ class PriorPartyBanner
         );
     }
 
+    /**
+     * Get the banner that should be displayed for the current post.
+     * 
+     * This doesn't check for a valid location or if it's opted out.
+     * That's so that a shortcode can be used to show the banner regardless of location or toggle value.
+     * 
+     * @param int $post_id
+     * 
+     * @return array|null
+     */
 
-    public function getBannerByPostId($post_id = null): ?array
+    public function getBannerByPostId(int $post_id): ?array
     {
-        // Return if an editor has opted-out of the banner.
-        if (get_field($this->post_field_name, $post_id) === false) {
-            return null;
-        }
-
         // Get the published date.
         $date = get_the_date('U', $post_id);
 
-        // Do any banners coincide with this date?
+        // Do any banners coincide with this date? 
         $banners = array_filter(
             $this->banners,
-            fn ($banner) => $date >= $banner['start_epoch'] && $date <= $banner['end_epoch']
+            // Using >= and < here to match:
+            // - times after and *including* 00:00:00 on the banner start date.
+            // - and times before, but *not including* 24:00:00 on the banner end date.
+            fn ($banner) => $date >= $banner['start_epoch'] && $date < $banner['end_epoch']
         );
 
         // If there are more than one banner, log an error. Possibly send to Sentry.
@@ -308,6 +334,11 @@ class PriorPartyBanner
             return;
         }
 
+        // Return if an editor has opted-out of the banner.
+        if (get_field($this->post_field_name, $post_id) === false) {
+            return;
+        }
+
         $banner = $this->getBannerByPostId($post_id);
 
         if (!$banner) {
@@ -317,6 +348,16 @@ class PriorPartyBanner
         // We have a banner to display.
         get_template_part('src/components/c-notification-banner/view', null, ['heading' => $banner['banner_content']]);
     }
+
+    /**
+     * Render the banner shortcode.
+     * 
+     * Run when the shortcode has been used in the content.
+     * If there's a banner that could be displayed, render it.
+     * The status of the toggle and the location rules are ignored.
+     * 
+     * @return void
+     */
 
     public function renderBannerShortcode()
     {
@@ -334,7 +375,18 @@ class PriorPartyBanner
         get_template_part('src/components/c-notification-banner/view', null, ['heading' => $banner['banner_content']]);
     }
 
-    public function modifyFieldInstructions($field)
+    /**
+     * Modify the instructions for the ACF field.
+     * 
+     * This is so that editors have a different message when there are no banners to display.
+     * i.e. they've just created a page, so re-word and use the future tense.
+     * 
+     * @param array $field
+     * 
+     * @return array
+     */
+
+    public function modifyFieldInstructions(array $field): array
     {
         // Are we on a post edit screen?
         $screen = get_current_screen();
@@ -345,6 +397,7 @@ class PriorPartyBanner
         // Get the published date.
         $date = get_the_date('U', get_the_ID());
 
+        // Load the banners from the ACF field.
         $this->loadBanners();
 
         // Do any banners coincide with this date?
@@ -355,6 +408,8 @@ class PriorPartyBanner
 
         // If there are no banners then re-word the instructions accordingly.
         if (empty($banners)) {
+            $field['ui_on_text'] = 'Yes';
+            $field['ui_off_text'] = 'No';
             $field['instructions'] = 'When a different government is is elected, should we show a ';
             $field['instructions'] .= 'banner to inform visitors that this content was published under a prior government?';
         }

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
@@ -168,9 +168,9 @@ class PriorPartyBanner
         $active_banners = array_filter(
             $mapped_banners,
             function ($banner) {
-                // If the user can edit posts then they can see all banners regardless of banner_active state.
-                // Else, other users (and logged out visitors) are only show banners that are active.
-                $user_can_view = current_user_can('edit_posts') || $banner['banner_active'] === true;
+                // If show-inactive is in the query string & the user can edit posts... they can see banners regardless of banner_active state.
+                // Else, other users (and logged out visitors) are only shown banners that are active.
+                $user_can_view = (isset($_GET['show-inactive']) && current_user_can('edit_posts')) || $banner['banner_active'] === true;
 
                 return ($user_can_view && $banner['end_epoch']) && ($banner['end_epoch'] <= $this->time_context);
             } 

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
@@ -170,7 +170,7 @@ class PriorPartyBanner
             function ($banner) {
                 // If show-inactive is in the query string & the user can edit posts... they can see banners regardless of banner_active state.
                 // Else, other users (and logged out visitors) are only shown banners that are active.
-                $user_can_view = (isset($_GET['show-inactive']) && current_user_can('edit_posts')) || $banner['banner_active'] === true;
+                $user_can_view = (isset($_GET['show_inactive']) && current_user_can('edit_posts')) || $banner['banner_active'] === true;
 
                 return ($user_can_view && $banner['end_epoch']) && ($banner['end_epoch'] <= $this->time_context);
             } 

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner.php
@@ -168,12 +168,12 @@ class PriorPartyBanner
         $active_banners = array_filter(
             $mapped_banners,
             function ($banner) {
-                // If show-inactive is in the query string & the user can edit posts... they can see banners regardless of banner_active state.
+                // If show_inactive is in the query string & the user can edit posts... they can see banners regardless of banner_active state.
                 // Else, other users (and logged out visitors) are only shown banners that are active.
                 $user_can_view = (isset($_GET['show_inactive']) && current_user_can('edit_posts')) || $banner['banner_active'] === true;
 
-                return ($user_can_view && $banner['end_epoch']) && ($banner['end_epoch'] <= $this->time_context);
-            } 
+                return $user_can_view && $banner['end_epoch'] && ($banner['end_epoch'] <= $this->time_context);
+            }
         );
 
         $this->banners = $active_banners;


### PR DESCRIPTION
This PR addressed the view of the Prior Party Banner:

- Comment the code
- Make end date inclusive, to match the admin WP_Query
- Improve repeater fields instructions
- Only use time_context when a banner's end date has not been passed
- Update logic around checking for editor or filtering out inactive banners
    As time_context is not always set for editors, use show_inactive query string.
- Fix shortcodes, render in correct place and with correct spacing.