### PR TITLE
Localise times add add scheduled emails

### DIFF
--- a/web/app/themes/clarity/acf-json/group_667d8381383f1.json
+++ b/web/app/themes/clarity/acf-json/group_667d8381383f1.json
@@ -132,6 +132,75 @@
                     "parent_repeater": "field_667d8381b4592"
                 }
             ]
+        },
+        {
+            "key": "field_668be710054be",
+            "label": "User Digest Emails",
+            "name": "prior_political_party_banners_digest_users",
+            "aria-label": "",
+            "type": "user",
+            "instructions": "Users to receive daily digest emails.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
+            },
+            "admin_only": 0,
+            "role": [
+                "administrator",
+                "agency_admin"
+            ],
+            "return_format": "array",
+            "multiple": 1,
+            "allow_null": 0
+        },
+        {
+            "key": "field_668bf3eefe765",
+            "label": "BCC Digest Emails",
+            "name": "prior_political_party_banners_digest_bcc",
+            "aria-label": "",
+            "type": "repeater",
+            "instructions": "A list of BCC emails for the digest emails.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "50",
+                "class": "",
+                "id": ""
+            },
+            "admin_only": 0,
+            "layout": "table",
+            "pagination": 0,
+            "min": 0,
+            "max": 0,
+            "collapsed": "",
+            "button_label": "Add email address",
+            "rows_per_page": 20,
+            "sub_fields": [
+                {
+                    "key": "field_668be7e71b6d6",
+                    "label": "BCC Email",
+                    "name": "user_email",
+                    "aria-label": "",
+                    "type": "email",
+                    "instructions": "",
+                    "required": 1,
+                    "conditional_logic": 0,
+                    "wrapper": {
+                        "width": "50",
+                        "class": "",
+                        "id": ""
+                    },
+                    "admin_only": 0,
+                    "default_value": "",
+                    "placeholder": "",
+                    "prepend": "",
+                    "append": "",
+                    "parent_repeater": "field_668bf3eefe765"
+                }
+            ]
         }
     ],
     "location": [
@@ -152,5 +221,5 @@
     "active": true,
     "description": "",
     "show_in_rest": 0,
-    "modified": 1720434982
+    "modified": 1720448176
 }

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
@@ -260,8 +260,10 @@ class PriorPartyBannerAdmin
 
                     // links
                     $link_admin = get_edit_post_link($post->ID);
-                    // The query string can be 0, 1, or 2 of: `preview_unpublished`, `time_context`.
-                    $link_view = get_permalink($post->ID) . '?' . http_build_query($link_view_queries);
+                    // Get the permalink, we'll test if it contains a ? to correctly append the query string.
+                    $permalink = get_permalink($post->ID);
+                    // Use ? or & appropriately. The query string can be 0, 1, or 2 of: `preview_unpublished`, `time_context`.
+                    $link_view = $permalink . (str_contains($permalink, '?') ? '&' : '?') . http_build_query($link_view_queries);
 
                     // latest event
                     $event_data = $this->getTrackedDisplayString($post->ID);
@@ -277,8 +279,8 @@ class PriorPartyBannerAdmin
                               <span class="nav-link"><a href="' . $link_view . '" target="_blank">View</a> | </span>
                               <span class="nav-link"><a href="' . $link_admin . '" target="_blank">Edit</a></span>';
 
-                    if (isset($event_data['date'])) {
-                        echo '<span class="event-data tool-tip" title-new="' . $event_data['date'] . '">' . $event_data['text'] . '</span>';
+                    if (isset($event_data['local_date'])) {
+                        echo '<span class="event-data tool-tip" title-new="' . $event_data['local_date'] . '">' . $event_data['text'] . '</span>';
                     }
 
                     echo '</div>';
@@ -426,7 +428,7 @@ class PriorPartyBannerAdmin
 
                 $this->posts = array_filter(
                     $query->get_posts(),
-                    fn($post) => $pp_banner->isValidLocation($post->ID)
+                    fn ($post) => $pp_banner->isValidLocation($post->ID)
                 );
             }
         }
@@ -575,7 +577,7 @@ class PriorPartyBannerAdmin
 
             // create the display string
             $event_data = [
-                'date' => $latest['date'] . ', ' . $latest['time'],
+                'local_date' => $latest['local_date'] . ', ' . $latest['local_time'],
                 'text' => $name . ' from ' . $latest['agency'] . ' ' . $latest['action'] . ' the banner'
             ];
         }

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-email.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-email.php
@@ -77,6 +77,14 @@ class PriorPartyBannerEmail
         return $date_object;
     }
 
+    /**
+     * A timezone aware function that will send digest emails to those set in the Options page.
+     * 
+     * @param array $props An array containing the DST status.
+     * 
+     * @return void
+     */
+
     public function maybeSendEmails($props)
     {
         // Is London currently observing DST?
@@ -88,32 +96,16 @@ class PriorPartyBannerEmail
             return;
         }
 
-        $users_to_email = get_field($this->user_field_name, 'option');
-
+        $users_to_email = get_field($this->user_field_name, 'option') ?: [];
         $bcc_addresses_to_email = get_field($this->bcc_field_name, 'option') ?: [];
-
-        $recipients = array_merge($users_to_email, $bcc_addresses_to_email);
+        $all_recipients = array_merge($users_to_email, $bcc_addresses_to_email);
 
         $timestamp_from = strtotime('yesterday 9:00 Europe/London');
         $timestamp_to = strtotime('today 9:00 Europe/London');
-
         $email_content = $this->getEmailDigestByTimes($timestamp_from, $timestamp_to);
 
-        foreach ($recipients as $recipient) {
-            $to = $recipient['user_email'];
-            $subject = $email_content['subject'];
-            $body = $email_content['body'];
-
-            echo '<pre>';
-            echo 'Emailing...';
-            print_r($to);
-            echo '<br/>';
-            print_r($subject);
-            echo '<br/>';
-            print_r($body);
-
-            echo '</pre>';
-            wp_mail($to, $subject, $body);
+        foreach ($all_recipients as $recipient) {
+            wp_mail($recipient['user_email'], $email_content['subject'], $email_content['body']);
         }
     }
 

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-email.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-email.php
@@ -21,6 +21,10 @@ class PriorPartyBannerEmail
      */
     private string $repeater_name = 'prior_political_party_banners';
 
+    private string $user_field_name = 'prior_political_party_banners_digest_users';
+
+    private string $bcc_field_name = 'prior_political_party_banners_digest_bcc';
+
 
     /**
      * @var string the name of the page for viewing banner posts
@@ -33,6 +37,84 @@ class PriorPartyBannerEmail
     public function __construct()
     {
         add_action('admin_menu', [$this, 'emailMenu']);
+
+        // Schedule the email digest.
+        // This will run the maybeSendEmails function twice a day.
+        // During winter, this will be 8am and 9am in the UK.
+        // During summer, this will be 9am and 10am in the UK.
+        // Running twice will ensure that one is run at 9am UK time.
+        // Params:
+        // - Unix timestamp (UTC) for when to next run the event.
+        // - How often the event should subsequently recur.
+        // - Action hook to execute when the event is run.
+
+        $args = ['dst' => true];
+        if (!wp_next_scheduled('prior_party_banner_email_cron_hook', $args)) {
+            wp_schedule_event(strtotime('08:02:00'), 'daily', 'prior_party_banner_email_cron_hook', $args);
+        }
+
+        $args = ['dst' => false];
+        if (!wp_next_scheduled('prior_party_banner_email_cron_hook', $args)) {
+            wp_schedule_event(strtotime('09:02:00'), 'daily', 'prior_party_banner_email_cron_hook', $args);
+        }
+
+        add_action('prior_party_banner_email_cron_hook', [$this, 'maybeSendEmails']);
+    }
+
+    /**
+     * A function to convert a timestamp to a local date object.
+     * 
+     * @param int $timestamp The timestamp.
+     * 
+     * @return \DateTime
+     */
+
+    public function timestampToLocalDateObject(int $timestamp): \DateTime
+    {
+        $date_object = new \DateTime();
+        $date_object->setTimezone(new \DateTimeZone('Europe/London'));
+        $date_object->setTimestamp($timestamp);
+        return $date_object;
+    }
+
+    public function maybeSendEmails($props)
+    {
+        // Is London currently observing DST?
+        $in_dst = strtotime("today 9:00 am Europe/London") !== strtotime("today 9:00 am UTC");
+
+        // If the current DST status doesn't match the props, return early.
+        if ($in_dst !== $props['dst']) {
+            // It's 10am in the summer or 8am in the winter - don't send emails.
+            return;
+        }
+
+        $users_to_email = get_field($this->user_field_name, 'option');
+
+        $bcc_addresses_to_email = get_field($this->bcc_field_name, 'option') ?: [];
+
+        $recipients = array_merge($users_to_email, $bcc_addresses_to_email);
+
+        $timestamp_from = strtotime('yesterday 9:00 Europe/London');
+        $timestamp_to = strtotime('today 9:00 Europe/London');
+
+        $email_content = $this->getEmailDigestByTimes($timestamp_from, $timestamp_to);
+
+        foreach ($recipients as $recipient) {
+            $to = $recipient['user_email'];
+            $subject = $email_content['subject'];
+            $body = $email_content['body'];
+
+            echo '<pre>';
+            echo 'Emailing...';
+            print_r($to);
+            echo '<br/>';
+            print_r($subject);
+            echo '<br/>';
+            print_r($body);
+
+            echo '</pre>';
+            wp_mail($to, $subject, $body);
+        }
     }
 
     /**
@@ -108,12 +190,15 @@ class PriorPartyBannerEmail
 
     public function emailPage(): void
     {
+
+        $this->maybeSendEmails(['dst' => true]);
+
         $is_after_nine = date('H', time()) >= 9;
 
         if ($is_after_nine) {
-            $time_window_start = strtotime('today 09:00');
+            $time_window_start = strtotime('today 09:00 Europe/London');
         } else {
-            $time_window_start = strtotime('yesterday 09:00');
+            $time_window_start = strtotime('yesterday 09:00 Europe/London');
         }
 
         $email_index = 0;
@@ -133,10 +218,12 @@ class PriorPartyBannerEmail
             // Get the email digest for this time window.
             $email = $this->getEmailDigestByTimes($from, $to);
 
-            // Echo out the email.
-            echo '<h2>Subject: ' . $email['subject'] . '</h2>';
-            echo '<p>' . $email['body'] . '</p>';
-            echo '<hr/>';
+            if ($email) {
+                // Echo out the email.
+                echo '<h2>Subject: ' . $email['subject'] . '</h2>';
+                echo '<pre>' . $email['body'] . '</pre>';
+                echo '<hr/>';
+            }
 
             $email_index++;
         }
@@ -152,14 +239,14 @@ class PriorPartyBannerEmail
 
     public function bannerArrayToText(array $banner): string
     {
-        $string = sprintf('<strong>%s</strong> <br/>', $banner['banner_content']);
+        $string = sprintf("Banner: %s \n", $banner['banner_content']);
 
         foreach ($banner['post_types'] as $post_type) {
-            $string .= sprintf('<strong>%s</strong>: %d opt-in, %d opt-out <br/>', $post_type['label'], $post_type['true_count'], $post_type['false_count']);
+            $string .= sprintf("%s: %d opt-in, %d opt-out\n", $post_type['label'], $post_type['true_count'], $post_type['false_count']);
         }
-        $string .= sprintf('<strong>Total changes</strong>: %s <br/>', $banner['change_count']);
+        $string .= sprintf("Total changes: %s\n", $banner['change_count']);
 
-        $string .= sprintf('<a href="%s">Review</a>', $banner['review_url']);
+        $string .= sprintf("Review: %s\n", $banner['review_url']);
 
         return $string;
     }
@@ -200,10 +287,10 @@ class PriorPartyBannerEmail
      * @param int $from
      * @param int $to
      * 
-     * @return array the email associative array with a subject and body.
+     * @return array|null the email associative array with a subject and body - or null for no changes.
      */
 
-    public function getEmailDigestByTimes(int $from, int $to): array
+    public function getEmailDigestByTimes(int $from, int $to): array|null
     {
         $events = $this->getTrackEvents(null, $from, $to);
 
@@ -295,22 +382,31 @@ class PriorPartyBannerEmail
          * End a loop over all the banners.
          */
 
+        // Filter out banners with no changes.
+        $banners = array_filter($banners, fn ($banner) => $banner['change_count'] > 0);
+
+        // Return early if there are no banners.
+        if (empty($banners)) {
+            return null;
+        }
 
         // Total changes for all banners.
         $total_change_count = array_reduce($banners, fn ($c, $s) => $c + $s['change_count'], 0);
 
-        $email_heading = sprintf('<h2>Email digest for %s to %s</h2>', date('jS F, Y - g:i a', $from),  date('jS F, Y - g:i a', $to));
+
+        $local_from_date = $this->timestampToLocalDateObject($from);
+        $local_to_date = $this->timestampToLocalDateObject($to);
+
+        $email_heading = sprintf("Email digest for %s to %s\n\n", $local_from_date->format('jS F - g:i a'),  $local_to_date->format('jS F - g:i a'));
         $email_bodies = array_map(fn ($b) => $b['email_body'], $banners);
 
         $email = [
             'subject' => sprintf('Moj Intranet - Prior Party Banner Digest %d recent changes', $total_change_count),
-            'body' => $email_heading . implode('<br/>', $email_bodies)
+            'body' => $email_heading . implode("\n\n", $email_bodies)
         ];
 
         return $email;
     }
-
-    // TODO: schedule task for digest emails.
 }
 
 new PriorPartyBannerEmail();

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-events.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-events.php
@@ -21,6 +21,22 @@ trait PriorPartyBannerTrackEvents
     private string $event_details_field = '_prior_party_banner_event_details';
 
     /**
+     * A function to convert a timestamp to a local date object.
+     * 
+     * @param int $timestamp The timestamp.
+     * 
+     * @return \DateTime
+     */
+
+    public function timestampToLocalDateObject (int $timestamp): \DateTime
+    {
+        $date_object = new \DateTime();
+        $date_object->setTimezone(new \DateTimeZone('Europe/London'));
+        $date_object->setTimestamp($timestamp);
+        return $date_object;
+    }
+
+    /**
      * Create a new track event.
      *
      * @param bool $value The value.
@@ -97,10 +113,12 @@ trait PriorPartyBannerTrackEvents
                 }
             }
 
+            $local_date = $this->timestampToLocalDateObject($event['time']);
+
             return [
                 'name' => $user->display_name ?: 'Unknown',
-                'date' => date('jS F Y', $event['time']),
-                'time' => date('H:i', $event['time']),
+                'local_date' => $local_date->format('jS F Y'),
+                'local_time' => $local_date->format('H:i'),
                 'agency' => $agency_name,
                 'action' => $event['action'] === 'true' ? 'displayed' : 'removed',
                 'tracked' => true
@@ -204,11 +222,12 @@ trait PriorPartyBannerTrackEvents
             return '';
         }
 
-        $time = date($this->date_format_time, $event['time']);
+        $local_date = $this->timestampToLocalDateObject($event['time']);
+        $local_time = $local_date->format($this->date_format_time);
         $user = get_user_by('id', $event['user_id']);
         $user_name = $user ? $user->display_name : 'Unknown';
 
-        return "User: $user_name,<br/> Action: {$event['action']},<br/> Time: $time";
+        return "User: $user_name,<br/> Action: {$event['action']},<br/> Time: $local_time";
     }
 
     // TODO: lifecycle policy, delete events older than x? Or keep only the most recent x events per post?

--- a/web/app/themes/clarity/inc/mail.php
+++ b/web/app/themes/clarity/inc/mail.php
@@ -53,6 +53,10 @@ add_filter('pre_wp_mail', function ($null, $mail) {
 
     // Don't short-circuit if the password doesn't look right
     $maybe_api_key = env('SMTP_PASSWORD') ?? env('SMTP_PASS');
+    if(empty($maybe_api_key)) {
+        // hand back to wp_mail()
+        return null;
+    }
     preg_match_all($patterns['api'], $maybe_api_key, $matches);
     if (count($matches[0]) !== 2) {
         // hand back to wp_mail()


### PR DESCRIPTION
This PR includes:

- Formatting of timestamps to local times
- Scheduled emails
- A fix for double ? in urls - including it here because it fixes a bug. Happy to change it if needs be.

The email content looks like:

<img width="557" alt="image" src="https://github.com/ministryofjustice/intranet/assets/15802017/11614713-4de7-45fb-ab7e-4098d22ce62a">

feedback is welcome.