### PR TITLE
CDPT-1773 Delete events older than a year (but keep one).

### DIFF
--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
@@ -91,7 +91,7 @@ class PriorPartyBannerAdmin
             wp_schedule_event(strtotime('01:35:00'), 'weekly', 'prior_party_banner_event_cleanup_cron_hook');
         }
         // Add the delete action to the schedule.
-        add_action('prior_party_banner_event_cleanup_cron_hook', [$this, 'deleteOldEvents']);
+        add_action('prior_party_banner_event_cleanup_cron_hook', [$this, 'deleteOldTrackEvents']);
 
         /**
          * Don't load view code until needed

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-admin.php
@@ -86,6 +86,13 @@ class PriorPartyBannerAdmin
         add_filter('acf/update_value/name=' . $this->post_field_name, [$this, 'trackBannerUpdates'], 10, 4);
         add_filter('acf/load_value/name=' . $this->post_field_name, [$this, 'filterValueOnPages'], 10, 2);
 
+        // Create a schedule for deleting old track events.
+        if (!wp_next_scheduled('prior_party_banner_event_cleanup_cron_hook')) {
+            wp_schedule_event(strtotime('01:35:00'), 'weekly', 'prior_party_banner_event_cleanup_cron_hook');
+        }
+        // Add the delete action to the schedule.
+        add_action('prior_party_banner_event_cleanup_cron_hook', [$this, 'deleteOldEvents']);
+
         /**
          * Don't load view code until needed
          */

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-events.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-events.php
@@ -34,7 +34,7 @@ trait PriorPartyBannerTrackEvents
      * @return \DateTime
      */
 
-    public function timestampToLocalDateObject (int $timestamp): \DateTime
+    public function timestampToLocalDateObject(int $timestamp): \DateTime
     {
         $date_object = new \DateTime();
         $date_object->setTimezone(new \DateTimeZone('Europe/London'));
@@ -167,6 +167,11 @@ trait PriorPartyBannerTrackEvents
      */
     public function getTrackEvents(int | null $post_id = null, int | null $from = null, int | null $to = null): array
     {
+
+        if ($from && $from < strtotime('-' . $this->max_age_in_days . ' days')) {
+            error_log('The events returned by getTrackEvents may be truncated due to old ones being deleted.');
+        }
+
         /**
          * A post_id was passed, so we only need to get the details for that post.
          */

--- a/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-events.php
+++ b/web/app/themes/clarity/inc/admin/prior-party/prior-party-banner-events.php
@@ -255,14 +255,14 @@ trait PriorPartyBannerTrackEvents
     }
 
     /**
-     * Delete old events.
+     * Delete old track events.
      * 
      * This function will delete all events older than the max age.
      * 
      * @return void
      */
 
-    public function deleteOldEvents(): void
+    public function deleteOldTrackEvents(): void
     {
         // Get the expiry date in timestamp format.
         $expiry_timestamp = strtotime('-' . $this->max_age_in_days . ' days');


### PR DESCRIPTION
This PR schedules a weekly event at 01:35

This runs an action to identify events older than 1 year and deletes them.

The most recent event is kept, so that we can always see who set the current toggle status.