### PR TITLE
CDPT-877 Add an ingress that is restricted by IP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
           # AWS_CLOUDFRONT_PUBLIC_KEY_EXPIRING: "${{ secrets.AWS_CLOUDFRONT_PUBLIC_KEY_B }}"
           BASIC_AUTH_USER: ${{ secrets.BASIC_AUTH_USER }}
           BASIC_AUTH_PASS: ${{ secrets.BASIC_AUTH_PASS }}
+          ALLOWED_IPS: ${{ secrets.ALLOWED_IPS }}
         run: |
           export AWS_CLOUDFRONT_PUBLIC_KEY_BASE64=$(echo -n "$AWS_CLOUDFRONT_PUBLIC_KEY" | base64 -w 0)
           export AWS_CLOUDFRONT_PRIVATE_KEY_BASE64=$(echo -n "$AWS_CLOUDFRONT_PRIVATE_KEY" | base64 -w 0)
@@ -65,12 +66,14 @@ jobs:
           export BASIC_AUTH_BASE64
 
           ## Perform find/replace
-          < "$TPL_PATH"/secret.tpl.yml envsubst > "$TPL_PATH"/secret.yaml
-          < "$TPL_PATH"/deployment.tpl.yml envsubst > "$TPL_PATH"/deployment.yaml
+          < "$TPL_PATH"/secret.tpl.yml                envsubst > "$TPL_PATH"/secret.yaml
+          < "$TPL_PATH"/deployment.tpl.yml            envsubst > "$TPL_PATH"/deployment.yaml
+          < "$TPL_PATH"/ingress-ip-restricted.tpl.yml envsubst > "$TPL_PATH"/ingress-ip-restricted.yaml
           
           ## Remove template files before apply
           rm "$TPL_PATH"/secret.tpl.yml
           rm "$TPL_PATH"/deployment.tpl.yml
+          rm "$TPL_PATH"/ingress-ip-restricted.tpl.yml
 
       - name: "Authenticate to the cluster"
         env:

--- a/deploy/development/ingress-ip-restricted.tpl.yml
+++ b/deploy/development/ingress-ip-restricted.tpl.yml
@@ -1,0 +1,30 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ${KUBE_NAMESPACE}-ip-restricted-ingress
+  namespace: ${KUBE_NAMESPACE}
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: intranet-dev-ip-restricted-ingress-intranet-dev-green
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/whitelist-source-range: ${ALLOWED_IPS}
+    nginx.ingress.kubernetes.io/server-snippet: |
+      # Redirect everything that's not for our specified endpoints.
+      location ~ ^/(?!(ip-restricted|info\.php)) {
+        rewrite ^/(.*) https://dev.intranet.justice.gov.uk/$1; 
+      }
+spec:
+  ingressClassName: default
+  tls:
+  - hosts:
+    - dev-intranet-ip-restricted.apps.live.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: dev-intranet-ip-restricted.apps.live.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx-service
+            port:
+              number: 8080

--- a/deploy/development/ingress-ip-restricted.tpl.yml
+++ b/deploy/development/ingress-ip-restricted.tpl.yml
@@ -4,7 +4,7 @@ metadata:
   name: ${KUBE_NAMESPACE}-ip-restricted-ingress
   namespace: ${KUBE_NAMESPACE}
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: intranet-dev-ip-restricted-ingress-intranet-dev-green
+    external-dns.alpha.kubernetes.io/set-identifier: ${KUBE_NAMESPACE}-ip-restricted-ingress-${KUBE_NAMESPACE}-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/whitelist-source-range: ${ALLOWED_IPS}
     nginx.ingress.kubernetes.io/server-snippet: |
@@ -16,9 +16,9 @@ spec:
   ingressClassName: default
   tls:
   - hosts:
-    - dev-intranet-ip-restricted.apps.live.cloud-platform.service.justice.gov.uk
+    - ${KUBE_NAMESPACE}-ip-restricted.apps.live.cloud-platform.service.justice.gov.uk
   rules:
-  - host: dev-intranet-ip-restricted.apps.live.cloud-platform.service.justice.gov.uk
+  - host: ${KUBE_NAMESPACE}-ip-restricted.apps.live.cloud-platform.service.justice.gov.uk
     http:
       paths:
       - path: /

--- a/deploy/development/ingress.yml
+++ b/deploy/development/ingress.yml
@@ -24,7 +24,7 @@ metadata:
       # Redirect a specific endpoint to the ip restricted endpoint. We can trust that a user at that path has not gone through this ingress.
       location = /ip-restricted {
         auth_basic off;
-        return 302 https://dev-intranet-ip-restricted.apps.live.cloud-platform.service.justice.gov.uk/ip-restricted;
+        return 302 https://intranet-dev-ip-restricted.apps.live.cloud-platform.service.justice.gov.uk/ip-restricted;
       }
 spec:
   ingressClassName: default

--- a/deploy/development/ingress.yml
+++ b/deploy/development/ingress.yml
@@ -10,9 +10,6 @@ metadata:
     nginx.ingress.kubernetes.io/auth-secret: basic-auth-secret
     nginx.ingress.kubernetes.io/auth-realm: 'Development Access | Authentication Required'
     nginx.ingress.kubernetes.io/server-snippet: |
-      if ($host = 'dev-intranet.apps.live.cloud-platform.service.justice.gov.uk') {
-        return 301 https://dev.intranet.justice.gov.uk;
-      }
       location = /health {
         auth_basic off;
         access_log off;
@@ -24,25 +21,18 @@ metadata:
         auth_basic off;
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
+      # Redirect a specific endpoint to the ip restricted endpoint. We can trust that a user at that path has not gone through this ingress.
+      location = /ip-restricted {
+        auth_basic off;
+        return 302 https://dev-intranet-ip-restricted.apps.live.cloud-platform.service.justice.gov.uk/ip-restricted;
+      }
 spec:
   ingressClassName: default
   tls:
   - hosts:
-    - dev-intranet.apps.live.cloud-platform.service.justice.gov.uk
-  - hosts:
     - dev.intranet.justice.gov.uk
     secretName: intranet-dev-cert-secret
   rules:
-  - host: dev-intranet.apps.live.cloud-platform.service.justice.gov.uk
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: nginx-service
-            port:
-              number: 8080
   - host: dev.intranet.justice.gov.uk
     http:
       paths:


### PR DESCRIPTION
This PR brings the IP level check out of the application and into Cloud Platform's ingress.

This way we can check an IP is allowed by sending a request to `https://dev-intranet-ip-restricted.apps.live.cloud-platform.service.justice.gov.uk/ip-restricted` (possibly by JS).

The feature is not complete, I will make application level changes in a different PR.

From the ticket:

- *.intranet.justice.gov.uk nor intranet.justice.gov.uk  is not routed through GlobalProtect.
- To save requesting Global Protect (and other VPNs?) to add *.intranet.justice.gov.uk to their routing we can have an auth endpoint at something like dev-intranet-api.apps.live.cloud-platform.service.justice.gov.uk
- *.service.justice.gov.uk  is already routed via Global Protect.
- This will be similar to the existing setup - it will not route all intranet browsing traffic through Global Protect, this is a good thing for saving bandwidth and low latency.