### PR TITLE
Copy /etc/nginx/php-fpm-auth.conf to build nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -220,6 +220,7 @@ FROM base-nginx AS build-nginx
 
 # Grab server configurations
 COPY deploy/config/php-fpm.conf /etc/nginx/php-fpm.conf
+COPY deploy/config/php-fpm-auth.conf /etc/nginx/php-fpm-auth.conf
 COPY deploy/config/server.conf /etc/nginx/conf.d/default.conf
 
 WORKDIR /var/www/html


### PR DESCRIPTION
Fixes

```
2024/07/30 07:54:37 [emerg] 1#1: open() "/etc/nginx/php-fpm-auth.conf" failed (2: No such file or directory) in /etc/nginx/conf.d/default.conf:145
```