### PR TITLE
CDPT-1893 Add auth docs.

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 
-# <img alt="MoJ logo" src="https://moj-logos.s3.eu-west-2.amazonaws.com/moj-uk-logo.png" width="200"/><br>Intranet
+# <img alt="MoJ logo" src="https://moj-logos.s3.eu-west-2.amazonaws.com/moj-uk-logo.png" width="200"><br>Intranet
 
 [![Standards Icon]][Standards Link]
 [![License Icon]][License Link]

--- a/.github/README.md
+++ b/.github/README.md
@@ -507,11 +507,14 @@ sequenceDiagram
     nginx->>Client: Content response
 ```
 
-#### OAuth Refresh
-
-
-
 ### Access control heartbeat
+
+In the background, as a visitor is browsing, javascript is requesting the `auth/heartbeat` endpoint.
+
+This is for 2 reasons:
+
+- It will keep the OAuth session fresh, the endpoint handler will refresh OAuth tokens, and update JWTs before they expire.
+- If a visitor's state has changed, e.g. they have moved from an office with an allowed IP, then their browser content is blurred and they are prompted to refresh the page.
 
 <!-- License -->
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -525,7 +525,7 @@ sequenceDiagram
     Note right of fpm: JWT indicates too many<br/>failed login attempts  ⛔️
     fpm->>nginx: 401, JWT & doc.
     nginx->>Client: Forward 401, JWT & doc.
-    Note left of Client: User sees static 401<br/>without redirect to /auth/login
+    Note left of Client: Static 401 error page<br/>without redirect to /auth/login ⛔️
 ```
 
 ### Access control heartbeat

--- a/.github/README.md
+++ b/.github/README.md
@@ -348,7 +348,7 @@ To verify that S3 & CloudFront are working correctly.
 The oauth2 flow should now work with the Azure AD/Entra ID application.
 You can get an Access Token, Refresh Token and an expiry of the token.
 
-## Access controls
+## Access control
 
 To view the intranet content, visitors must meet one of the following criteria.
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -507,6 +507,27 @@ sequenceDiagram
     nginx->>Client: Content response
 ```
 
+#### Failed logins
+
+This diagram shows how a user will not be redirected to `/auth/login` after too many failed login attempts.
+
+Nginx is transparent for these requests, so it's omitted from the diagram.
+
+```mermaid
+sequenceDiagram
+    actor Client
+    Note left of Client: Unprivileged IP &<br/>3 failed callback attempts
+    Client->>nginx: Content request
+    nginx->>nginx (/auth/verify): Auth subrequest
+    Note right of nginx (/auth/verify): geo module ⛔️
+    nginx (/auth/verify)->>nginx: 401 response code
+    nginx->>fpm: Load dynamic 401 page
+    Note right of fpm: JWT indicates too many<br/>failed login attempts  ⛔️
+    fpm->>nginx: 401, JWT & doc.
+    nginx->>Client: Forward 401, JWT & doc.
+    Note left of Client: User sees static 401<br/>without redirect to /auth/login
+```
+
 ### Access control heartbeat
 
 In the background, as a visitor is browsing, javascript is requesting the `auth/heartbeat` endpoint.


### PR DESCRIPTION
This PR adds docs surrounding the IP allow list and OAuth flow.

It also removes an unnecessary extra closing `div` tag.

To see the rendered sequence diagrams. check https://github.com/ministryofjustice/intranet/tree/CDPT-1893-auth-docs