### PR TITLE
Adjust the update strategy

### DIFF
--- a/deploy/staging/deployment.tpl.yml
+++ b/deploy/staging/deployment.tpl.yml
@@ -7,11 +7,6 @@ metadata:
     app: ${KUBE_NAMESPACE}
 spec:
   replicas: 4
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 100%
   selector:
     matchLabels:
       app: ${KUBE_NAMESPACE}

--- a/deploy/staging/deployment.tpl.yml
+++ b/deploy/staging/deployment.tpl.yml
@@ -7,6 +7,11 @@ metadata:
     app: ${KUBE_NAMESPACE}
 spec:
   replicas: 4
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 50%
+      maxSurge: 50%
   selector:
     matchLabels:
       app: ${KUBE_NAMESPACE}


### PR DESCRIPTION
When we release new updates, Kubernetes will destroy a pod and create a new one in its place.  It will do this in a non-destructive way, always leaving a working pod behind should the update fail.

In our scenario, we were saying that 100% of 4 pods can be alive (8) and zero pods can be unavailable during the update. This is strict and unnecessary.

Our new settings allow Kubernetes to permit 50% of pods above the allowed (2 extra pods = 6) and the max unavailable is 50% meaning we always have 2 pods that are healthy and running during the update, this = no downtime in a controlled manner.