### PR TITLE
Add a basic service dashboard and slack webhook secret.

### DIFF
--- a/deploy/development/service-dashboard.yml
+++ b/deploy/development/service-dashboard.yml
@@ -1,0 +1,736 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: intranet-service-dashboard
+  namespace: intranet-dev
+  labels:
+    grafana_dashboard: "intranet-dev-service"
+data:
+  intranet-dev-service-dashboard.json: |
+    {
+    "annotations": {
+        "list": [
+        {
+            "builtIn": 1,
+            "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+        }
+        ]
+    },
+    "description": "",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 172,
+    "links": [],
+    "panels": [
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+        },
+        "description": "The http status code when accessing an open site.\n\nThis should always be 200.",
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "text": "N/A"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "short"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 0
+        },
+        "id": 14,
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "lastNotNull"
+            ],
+            "fields": "/^Value$/",
+            "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+        },
+        "pluginVersion": "10.4.0",
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "dsType": "influxdb",
+            "editorMode": "code",
+            "expr": "http_status_code_control{namespace=\"$namespace\"}",
+            "format": "table",
+            "groupBy": [
+                {
+                "params": [
+                    "$__interval"
+                ],
+                "type": "time"
+                },
+                {
+                "params": [
+                    "null"
+                ],
+                "type": "fill"
+                }
+            ],
+            "hide": false,
+            "intervalFactor": 2,
+            "legendFormat": "__auto",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "range": true,
+            "refId": "A",
+            "resultFormat": "time_series",
+            "select": [
+                [
+                {
+                    "params": [
+                    "value"
+                    ],
+                    "type": "field"
+                },
+                {
+                    "params": [],
+                    "type": "mean"
+                }
+                ]
+            ],
+            "step": 2,
+            "tags": []
+            }
+        ],
+        "timeFrom": "1m",
+        "title": "Control (gov.uk)",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+        },
+        "description": "The http status code of /health.\n\nThis should always be 200.",
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "text": "N/A"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "short"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 0
+        },
+        "id": 13,
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "lastNotNull"
+            ],
+            "fields": "/^Value$/",
+            "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+        },
+        "pluginVersion": "10.4.0",
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "dsType": "influxdb",
+            "editorMode": "code",
+            "expr": "http_status_code_health{namespace=\"$namespace\"}",
+            "format": "table",
+            "groupBy": [
+                {
+                "params": [
+                    "$__interval"
+                ],
+                "type": "time"
+                },
+                {
+                "params": [
+                    "null"
+                ],
+                "type": "fill"
+                }
+            ],
+            "hide": false,
+            "intervalFactor": 2,
+            "legendFormat": "__auto",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "range": true,
+            "refId": "A",
+            "resultFormat": "time_series",
+            "select": [
+                [
+                {
+                    "params": [
+                    "value"
+                    ],
+                    "type": "field"
+                },
+                {
+                    "params": [],
+                    "type": "mean"
+                }
+                ]
+            ],
+            "step": 2,
+            "tags": []
+            }
+        ],
+        "timeFrom": "1m",
+        "title": "Health",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+        },
+        "description": "The http status code when accessing this service via it's full url as defined in WP_HOME.\n\nThis should be 200 or 401 depending on the namespace.",
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "text": "N/A"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "short"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 12,
+            "y": 0
+        },
+        "id": 3,
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "lastNotNull"
+            ],
+            "fields": "/^Value$/",
+            "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+        },
+        "pluginVersion": "10.4.0",
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "dsType": "influxdb",
+            "editorMode": "code",
+            "expr": "http_status_code_wp_home{namespace=\"$namespace\"}",
+            "format": "table",
+            "groupBy": [
+                {
+                "params": [
+                    "$__interval"
+                ],
+                "type": "time"
+                },
+                {
+                "params": [
+                    "null"
+                ],
+                "type": "fill"
+                }
+            ],
+            "hide": false,
+            "intervalFactor": 2,
+            "legendFormat": "__auto",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "range": true,
+            "refId": "A",
+            "resultFormat": "time_series",
+            "select": [
+                [
+                {
+                    "params": [
+                    "value"
+                    ],
+                    "type": "field"
+                },
+                {
+                    "params": [],
+                    "type": "mean"
+                }
+                ]
+            ],
+            "step": 2,
+            "tags": []
+            }
+        ],
+        "timeFrom": "1m",
+        "title": "Home",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+        },
+        "description": "The http status code of when sending X-Moj-Ip-Group header.\n\nThis should always be 400.",
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "thresholds"
+            },
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "text": "N/A"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "short"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 0
+        },
+        "id": 12,
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "lastNotNull"
+            ],
+            "fields": "/^Value$/",
+            "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+        },
+        "pluginVersion": "10.4.0",
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "dsType": "influxdb",
+            "editorMode": "code",
+            "expr": "http_status_code_invalid_header{namespace=\"$namespace\"}",
+            "format": "table",
+            "groupBy": [
+                {
+                "params": [
+                    "$__interval"
+                ],
+                "type": "time"
+                },
+                {
+                "params": [
+                    "null"
+                ],
+                "type": "fill"
+                }
+            ],
+            "hide": false,
+            "intervalFactor": 2,
+            "legendFormat": "__auto",
+            "orderByTime": "ASC",
+            "policy": "default",
+            "range": true,
+            "refId": "A",
+            "resultFormat": "time_series",
+            "select": [
+                [
+                {
+                    "params": [
+                    "value"
+                    ],
+                    "type": "field"
+                },
+                {
+                    "params": [],
+                    "type": "mean"
+                }
+                ]
+            ],
+            "step": 2,
+            "tags": []
+            }
+        ],
+        "timeFrom": "1m",
+        "title": "Invalid header",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "palette-classic"
+            },
+            "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "axisSoftMin": -1,
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineStyle": {
+                "fill": "solid"
+                },
+                "lineWidth": 1,
+                "pointSize": 6,
+                "scaleDistribution": {
+                "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": true,
+                "stacking": {
+                "group": "A",
+                "mode": "none"
+                },
+                "thresholdsStyle": {
+                "mode": "off"
+                }
+            },
+            "mappings": [
+                {
+                "options": {
+                    "200": {
+                    "index": 0,
+                    "text": "200 OK"
+                    },
+                    "400": {
+                    "index": 1,
+                    "text": "400 Bad Request"
+                    },
+                    "401": {
+                    "index": 2,
+                    "text": "401 Unauthorized"
+                    }
+                },
+                "type": "value"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            }
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+        },
+        "id": 11,
+        "options": {
+            "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+            },
+            "tooltip": {
+            "mode": "single",
+            "sort": "none"
+            }
+        },
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "http_status_code_health{namespace=\"$namespace\"}",
+            "instant": false,
+            "legendFormat": "{{__name__}}",
+            "range": true,
+            "refId": "A"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "http_status_code_wp_home{namespace=\"$namespace\"}",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "legendFormat": "{{__name__}}",
+            "range": true,
+            "refId": "B"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "http_status_code_invalid_header{namespace=\"$namespace\"}",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{__name__}}",
+            "range": true,
+            "refId": "C"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "http_status_code_control{namespace=\"$namespace\"}",
+            "hide": false,
+            "instant": false,
+            "legendFormat": "{{__name__}}",
+            "range": true,
+            "refId": "D"
+            }
+        ],
+        "title": "Stauts Codes",
+        "type": "timeseries"
+        }
+    ],
+    "refresh": false,
+    "schemaVersion": 39,
+    "tags": [],
+    "templating": {
+        "list": [
+        {
+            "current": {
+            "selected": true,
+            "text": "intranet-dev",
+            "value": "intranet-dev"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+            },
+            "definition": "label_values(http_status_code_wp_home,namespace)",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": {
+            "qryType": 1,
+            "query": "label_values(http_status_code_wp_home,namespace)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 2,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        }
+        ]
+    },
+    "time": {
+        "from": "now-15m",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+        ],
+        "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+        ]
+    },
+    "timezone": "",
+    "title": "Intranet Service",
+    "uid": "bdwyqxz07sxkwg",
+    "version": 1,
+    "weekStart": ""
+    }

--- a/deploy/production/secret.tpl.yml
+++ b/deploy/production/secret.tpl.yml
@@ -52,8 +52,8 @@ kind: Secret
 metadata:
   # The Slack webhook for #cdpt-intranet-and-justice-cloud-platform-alerts
   # Created via the Webhooks CDPT Slack App.
-  # This may be used for all environments and the Justice UK namespaces.
-  name: intranet-and-justice-slack-webhook
+  # This may be used for all intranet environments.
+  name: intranet-alerts-slack-webhook
 type: Opaque
 data:
-  slack-webhook-url: "${INTRANET_AND_JUSTICE_SLACK_WEBHOOK}"
+  url: "${ALERTS_SLACK_WEBHOOK}"

--- a/deploy/production/secret.tpl.yml
+++ b/deploy/production/secret.tpl.yml
@@ -46,3 +46,14 @@ metadata:
 type: Opaque
 data:
   auth: "${BASIC_AUTH_BASE64}"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  # The Slack webhook for #cdpt-intranet-and-justice-cloud-platform-alerts
+  # Created via the Webhooks CDPT Slack App.
+  # This may be used for all environments and the Justice UK namespaces.
+  name: intranet-and-justice-slack-webhook
+type: Opaque
+data:
+  slack-webhook-url: "${INTRANET_AND_JUSTICE_SLACK_WEBHOOK}"


### PR DESCRIPTION
This PR adds:

A basic dash to help visualise the metrics from the service monitor

<img width="1189" alt="image" src="https://github.com/user-attachments/assets/7efd4e0f-815c-4b9e-bbfd-573c58bc977e">

A Slack webhhok secret - required by Cloud Platform team for custom alerts.