### PR TITLE
CDPT-1928 - Ensure correct scheme when signing cookies for php's request to cdn.

### DIFF
--- a/public/app/themes/clarity/inc/amazon-s3-and-cloudfront-signing.php
+++ b/public/app/themes/clarity/inc/amazon-s3-and-cloudfront-signing.php
@@ -52,7 +52,7 @@ class AmazonS3AndCloudFrontSigning
         add_filter('http_request_args', function ($args, $url) {
             // Send cookies with the request to the cdn.
             if (parse_url($url, PHP_URL_HOST) ===  $this->cloudfront_host) {
-                $args['cookies'] = $this->createSignedCookie($this->cloudfront_url . '/*');
+                $args['cookies'] = $this->createSignedCookie(parse_url($url, PHP_URL_SCHEME) . '://' . $this->cloudfront_host . '/*');
             }
 
             $request_is_for_self = str_starts_with($url, home_url());


### PR DESCRIPTION
This PR fixes a bug where ewww could not optimise images on demand.

Behind the scenes 

1.  a http request was being made
2. A signed cooke was being added to the request, but it was for all of the cdn content but only via http
3. Access was denied to the cdn (https://cdn...), so images couldn't be downloaded and optimied.

Solution: the signed cookie policy should have the correct scheme/protocol as defined by the request $url.