### PR TITLE
CDPT-1239 - Update nginx config and add service & pod monitors.

### DIFF
--- a/deploy/config/local/nginx/server.conf
+++ b/deploy/config/local/nginx/server.conf
@@ -32,6 +32,15 @@ geo $ip_group {
     include /etc/nginx/geo.conf;
 }
 
+map $ip_group $ip_skip_oauth {
+    0       0; # Default IP group value
+    1       1; # Allowed IPs
+    2       1; # Allowed IPs (depricating)
+    3       0; # Cloud Platform IPs
+    4       1; # Local IP
+    default 0; # Default value
+}
+
 server {
     listen  8080 default_server; # For default requests.
     server_name localhost;
@@ -175,7 +184,7 @@ server {
         # Internal only, so /auth/verify can not be accessed from outside.
         internal;
 
-        if ( $ip_group != 0 ) {
+        if ($ip_skip_oauth = 1) {
             add_header Content-Type text/plain;
             return 200;
         }

--- a/deploy/config/server.conf
+++ b/deploy/config/server.conf
@@ -32,6 +32,28 @@ geo $ip_group {
     include /etc/nginx/geo.conf;
 }
 
+# Map IP groups to capabilities.
+
+map $ip_group $ip_skip_oauth {
+    0       0; # Default IP group value
+    1       1; # Allowed IPs
+    2       1; # Allowed IPs (depricating)
+    3       0; # Cloud Platform IPs
+    4       1; # Local IP (127.0.0.1)
+    default 0; # Default value
+}
+
+map $ip_group $ip_access_cron {
+    4       1; # Local IP (127.0.0.1)
+    default 0; # Default value
+}
+
+map $ip_group $ip_access_metrics {
+    3       1; # Cloud Platform IPs
+    4       1; # Local IP (127.0.0.1)
+    default 0; # Default value
+}
+
 server {
     listen  8080 default_server; # For default requests.
     server_name localhost;
@@ -170,7 +192,7 @@ server {
         # Internal only, so /auth/verify can not be accessed from outside.
         internal;
 
-        if ( $ip_group != 0 ) {
+        if ($ip_skip_oauth = 1) {
             add_header X-Moj-Ip-Group $ip_group;
             add_header Content-Type text/plain;
             return 200;
@@ -236,8 +258,7 @@ server {
 
     # Allow cron from internal network only.
     location = /wp/wp-cron.php {
-        # Group 4 is set to 127.0.0.1
-        if ( $ip_group != 4 ) {
+        if ($ip_access_cron = 0) {
             add_header Content-Type text/plain;
             return 401;
         }
@@ -262,8 +283,7 @@ server {
     }
 
     location ~ ^/metrics/fpm {
-        # Group 3 is set to the internal Cloud Platform IP range.
-        if ( $ip_group != 3 ) {
+        if ($ip_access_metrics = 0) {
             add_header Content-Type text/plain;
             return 401;
         }

--- a/deploy/demo/deployment.tpl.yml
+++ b/deploy/demo/deployment.tpl.yml
@@ -32,6 +32,7 @@ spec:
           image: ${ECR_URL}:${IMAGE_TAG_NGINX}
           ports:
             - containerPort: 8080
+              name: http
           volumeMounts:
             - name: uploads
               mountPath: /var/www/html/public/app/uploads

--- a/deploy/demo/network-policy.yml
+++ b/deploy/demo/network-policy.yml
@@ -1,0 +1,16 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: intranet-demo
+spec:
+  podSelector:
+    matchLabels:
+      app: intranet-demo
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/deploy/demo/pod-monitor.yml
+++ b/deploy/demo/pod-monitor.yml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: intranet-demo
+  namespace: intranet-demo
+spec:
+  selector:
+    matchLabels:
+      app: intranet-demo
+  podMetricsEndpoints:
+  - port: http
+    path: "/metrics/fpm"
+    interval: 15s

--- a/deploy/demo/service-monitor.yml
+++ b/deploy/demo/service-monitor.yml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: intranet-demo
+  namespace: intranet-demo
+spec:
+  selector:
+    matchLabels:
+      app: intranet-demo
+  endpoints:
+  - port: http
+    interval: 15s
+    path: /metrics/service

--- a/deploy/demo/service.yml
+++ b/deploy/demo/service.yml
@@ -7,5 +7,6 @@ metadata:
 spec:
   ports:
   - port: 8080
+    name: http
   selector:
     app: intranet-demo

--- a/deploy/development/alerts.yml
+++ b/deploy/development/alerts.yml
@@ -1,0 +1,29 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  namespace: intranet-dev
+  labels:
+    role: alert-rules
+  name: prometheus-custom-rules-intranet-dev
+spec:
+  groups:
+  - name: application-rules
+    rules:
+    - alert: ServiceInsufficientAccessPolicy
+      expr: http_status_code_wp_home{namespace="intranet-dev"} != 401
+      for: 1m
+      labels:
+        severity: intranet-dev
+      annotations:
+        message: Namespace {{ $labels.namespace }} (homepage) is returning an unexpected status code {{ printf "%0.0f" $value}}.
+        runbook_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/bdwyqxz07sxkwg/intranet-service?orgId=1
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/bdwyqxz07sxkwg/intranet-service?orgId=1
+    - alert: ServiceInsufficientHeaderHandling
+      expr: http_status_code_invalid_header{namespace="intranet-dev"} != 400
+      for: 1m
+      labels:
+        severity: intranet-dev
+      annotations:
+        message: Namespace {{ $labels.namespace } (invalid header) is returning an unexpected status code {{ printf "%0.0f" $value}}.
+        runbook_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/bdwyqxz07sxkwg/intranet-service?orgId=1
+        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/bdwyqxz07sxkwg/intranet-service?orgId=1

--- a/deploy/staging/deployment.tpl.yml
+++ b/deploy/staging/deployment.tpl.yml
@@ -32,6 +32,7 @@ spec:
           image: ${ECR_URL}:${IMAGE_TAG_NGINX}
           ports:
             - containerPort: 8080
+              name: http
           volumeMounts:
             - name: uploads
               mountPath: /var/www/html/public/app/uploads

--- a/deploy/staging/network-policy.yml
+++ b/deploy/staging/network-policy.yml
@@ -1,0 +1,16 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: intranet-staging
+spec:
+  podSelector:
+    matchLabels:
+      app: intranet-staging
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/deploy/staging/pod-monitor.yml
+++ b/deploy/staging/pod-monitor.yml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: intranet-staging
+  namespace: intranet-staging
+spec:
+  selector:
+    matchLabels:
+      app: intranet-staging
+  podMetricsEndpoints:
+  - port: http
+    path: "/metrics/fpm"
+    interval: 15s

--- a/deploy/staging/service-monitor.yml
+++ b/deploy/staging/service-monitor.yml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: intranet-staging
+  namespace: intranet-staging
+spec:
+  selector:
+    matchLabels:
+      app: intranet-staging
+  endpoints:
+  - port: http
+    interval: 15s
+    path: /metrics/service

--- a/deploy/staging/service.yml
+++ b/deploy/staging/service.yml
@@ -7,5 +7,6 @@ metadata:
 spec:
   ports:
   - port: 8080
+    name: http
   selector:
     app: intranet-staging


### PR DESCRIPTION
This PR:

- Adds `$ip_skip_oauth`, this allows us to block `Cloud Platform IPs` from accessing the service.

  This in turn means the `metrics/service` endpoint will correctly report a status code of 401 when trying to access the homepage on staging & production.

- ServiceMonitors and PodMonitors have been declared for Demo and Staging environments.

- Alerts have been declared for dev, after this PR, similar alerts will be set for demo and staging.