### PR TITLE
CDPT-1239 Correctly allow access to `/metrics/service`

### DIFF
--- a/deploy/config/server.conf
+++ b/deploy/config/server.conf
@@ -282,10 +282,9 @@ server {
         fastcgi_pass fpm;
     }
 
-    location ~ ^/metrics/fpm {
+    location = /metrics/fpm {
         if ($ip_access_metrics = 0) {
-            add_header Content-Type text/plain;
-            return 401;
+            return 404;
         }
 
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
@@ -300,6 +299,15 @@ server {
 
         # Set content type, so we can view in a browser - without a file download.
         add_header Content-Type text/plain;
+    }
+
+    location = /metrics/service {
+        if ($ip_access_metrics = 0) {
+            return 404;
+        }
+
+        fastcgi_param HTTP_X_MOJ_IP_GROUP $ip_group;
+        rewrite /metrics/service /index.php?$args;
     }
 
 }


### PR DESCRIPTION
Re use of 404s here.

I've used them, else it redirects the user to login.

> Servers may also send this response instead of 403 Forbidden to hide the existence of a resource from an unauthorized client. This response code is probably the most well known due to its frequent occurrence on the web.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses