### PR TITLE
CDPT-1239 If IGNORE_IP_RANGES is true, still set local and cloud platform IP groups.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,20 +86,11 @@ jobs:
           ## IP Ranges - - - - -
           ## - - - - - - - - - -
 
-          ## Allow IP ranges to be ignored.
-          ## Nb. set IGNORE_IP_RANGES env var to `true` for the intended GH environment.
-
-          IPS_FORMATTED_BASE64=$(
+          export IPS_FORMATTED_BASE64=$(
             echo -n "${{ inputs.ips_formatted }}" | 
             openssl enc -aes-256-cbc -pbkdf2 -base64 -d -salt -k "${{ secrets.WORKFLOW_ENCRYPTION_KEY }}"
           );
 
-          
-          if [ "$IGNORE_IP_RANGES" = "true" ]; then
-            IPS_FORMATTED_BASE64=""
-          fi
-
-          export IPS_FORMATTED_BASE64
 
           ## - - - - - - - - - - -
           ## Modsec config
@@ -110,6 +101,7 @@ jobs:
             openssl enc -aes-256-cbc -pbkdf2 -base64 -d -salt -k "${{ secrets.WORKFLOW_ENCRYPTION_KEY }}" |
             base64 --decode
           );
+
 
           ## - - - - - - - - - - -
           ## Perform find/replace

--- a/.github/workflows/ip-ranges-configure.yml
+++ b/.github/workflows/ip-ranges-configure.yml
@@ -40,6 +40,14 @@ jobs:
           ALLOW_FORMATTED=$(yq 'explode(.) | .allow_access_to_moj_intranet       | flatten | map(. + " '$ALLOW_VALUE';") | join("\n")' moj-cidr-addresses.yml)
           DEPRI_FORMATTED=$(yq 'explode(.) | .deprecating_access_to_moj_intranet | flatten | map(. + " '$DEPRI_VALUE';") | join("\n")' moj-cidr-addresses.yml)
 
+          # Allow IP ranges to be ignored.
+          # Nb. set IGNORE_IP_RANGES env var to `true` for the intended GH environment.
+
+          if [ "${{ vars.IGNORE_IP_RANGES }}" = "true" ]; then
+            ALLOW_FORMATTED=""
+            DEPRI_FORMATTED=""
+          fi
+
           # Below is a line for LB_RANGE - trust these internal IPs to correctly report HTTP_X_FORWARDED_FOR.
           # `127.0.0.1 $LOCAL_VALUE;` - allows requests from fpm to nginx containers.
 


### PR DESCRIPTION
This change is required to get metrics from the service and pods even when `IGNORE_IP_RANGES=true`.

It's the reason we don't have the intranet-demo namespace in this dashboard

https://grafana.live.cloud-platform.service.justice.gov.uk/d/bdwyqxz07sxkwg/intranet-service?orgId=1&var-namespace=intranet-staging