### PR TITLE
CDPT-1239 Update dashboard and alerts to cater for basic auth on dev & demo.

### DIFF
--- a/deploy/demo/alerts.yml
+++ b/deploy/demo/alerts.yml
@@ -28,13 +28,3 @@ spec:
         message: Namespace {{ $labels.namespace }} (homepage) is not returning a status code.
         runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/CDPT/pages/5124292758/Alerts+runbooks#ServiceAbsentAccessPolicy
         dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/bdwyqxz07sxkwg/intranet-service?orgId=1&var-namespace=intranet-demo
-
-    - alert: ServiceInsufficientHeaderHandling
-      expr: http_status_code_invalid_header{namespace="intranet-demo"} != 400
-      for: 1m
-      labels:
-        severity: intranet-demo
-      annotations:
-        message: Namespace {{ $labels.namespace }} (invalid header) is returning an unexpected status code {{ printf "%0.0f" $value}}.
-        runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/CDPT/pages/5124292758/Alerts+runbooks#ServiceInsufficientHeaderHandling
-        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/bdwyqxz07sxkwg/intranet-service?orgId=1&var-namespace=intranet-demo

--- a/deploy/development/alerts.yml
+++ b/deploy/development/alerts.yml
@@ -28,13 +28,3 @@ spec:
         message: Namespace {{ $labels.namespace }} (homepage) is not returning a status code.
         runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/CDPT/pages/5124292758/Alerts+runbooks#ServiceAbsentAccessPolicy
         dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/bdwyqxz07sxkwg/intranet-service?orgId=1
-
-    - alert: ServiceInsufficientHeaderHandling
-      expr: http_status_code_invalid_header{namespace="intranet-dev"} != 400
-      for: 1m
-      labels:
-        severity: intranet-dev
-      annotations:
-        message: Namespace {{ $labels.namespace }} (invalid header) is returning an unexpected status code {{ printf "%0.0f" $value}}.
-        runbook_url: https://dsdmoj.atlassian.net/wiki/spaces/CDPT/pages/5124292758/Alerts+runbooks#ServiceInsufficientHeaderHandling
-        dashboard_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/bdwyqxz07sxkwg/intranet-service?orgId=1

--- a/deploy/development/service-dashboard.yml
+++ b/deploy/development/service-dashboard.yml
@@ -471,7 +471,7 @@ data:
             "type": "prometheus",
             "uid": "prometheus"
         },
-        "description": "The status when sending an X-Moj-Ip-Group header.\n\nThis should always be 400 (✅). A cross (❌) will display when any other value is presented.",
+        "description": "The status when sending an X-Moj-Ip-Group header.\n\nThis should always be 400 or 401 (✅) depending on ingress basic auth being disabled, or enabled, respectively. A cross (❌) will display when any other value is presented.",
         "fieldConfig": {
             "defaults": {
             "color": {
@@ -480,12 +480,14 @@ data:
             "mappings": [
                 {
                 "options": {
-                    "400": {
+                    "from": 400,
+                    "result": {
                     "index": 1,
                     "text": "✅"
-                    }
+                    },
+                    "to": 401
                 },
-                "type": "value"
+                "type": "range"
                 },
                 {
                 "options": {
@@ -510,7 +512,7 @@ data:
                 },
                 {
                 "options": {
-                    "from": 401,
+                    "from": 402,
                     "result": {
                     "index": 3,
                     "text": "❌"


### PR DESCRIPTION
This PR removes 2 unnecessary alerts and updates the dashboard.

This is because, when basic auth is enabled (on dev and demo), there is no way to test for a 400 status from the nginx pod.