### PR TITLE
Fix: ElasticPress. Filter out post_author and other unused fields.

### DIFF
--- a/public/app/themes/clarity/inc/admin/plugins/wp-elasticsearch.php
+++ b/public/app/themes/clarity/inc/admin/plugins/wp-elasticsearch.php
@@ -1,13 +1,24 @@
 <?php
+
 /**
  * Modifications to adapt the ElasticPress plugin.
  *
  * @package Clarity
  **/
+
 namespace MOJ\Intranet;
 
 class WPElasticPress
 {
+
+    const REMOVE_FIELDS = [
+        'post_author',
+        'comment_count',
+        'comment_status',
+        'ping_status',
+        'menu_order',
+    ];
+
     public function __construct()
     {
         // do early stuff here, outside WP ecosys...
@@ -21,13 +32,15 @@ class WPElasticPress
         add_filter('ep_search_post_return_args', [$this, 'removeUnsetFields']);
     }
 
+    /**
+     * Filter post object fields/properties
+     *
+     * @param string[] $properties Post properties
+     * @return string[] Filtered properties
+     */
     public function removeUnsetFields($properties)
     {
-        unset($properties['post_author']);
-        unset($properties['comment_count']);
-        unset($properties['comment_status']);
-        unset($properties['ping_status']);
-        unset($properties['menu_order']);
+        $properties = array_filter($properties, fn($p) => !in_array($p, $this::REMOVE_FIELDS));
 
         return $properties;
     }


### PR DESCRIPTION
This PR modifies the way entries are removed from the array in `removeUnsetFields`.

As the array entries are indexed (not associative), `unset` has been changed to a `filter`.