### PR TITLE
Fix fpm-readiness syntax & add status script

### DIFF
--- a/bin/fpm-readiness.sh
+++ b/bin/fpm-readiness.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env ash
 
-# Send a ping request via fcgi
-PING_RESPONSE=$(SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock | tail -1);
+# Send a ping request via fcgi. Use an empty environment with `env -i`.
+PING_RESPONSE=$(env -i SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock | tail -1);
 
 # Exit with code 1 if the ping response was not 'pong'.
-if [ $(echo $PING_RESPONSE) != 'pong' ]; then exit 1; fi;
+if [ "$PING_RESPONSE" != 'pong' ]; then exit 1; fi;
 
-# Request the fpm status via fcgi
-FPM_STATUS=$(SCRIPT_NAME=/status SCRIPT_FILENAME=/status REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock);
+# Request the fpm status via fcgi.
+FPM_STATUS=$(env -i SCRIPT_NAME=/status SCRIPT_FILENAME=/status REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock);
 
 # Exit with code 1 if the status is 'Could not connect to /sock/fpm.sock'.
 if [ $(echo "$FPM_STATUS" | grep -c 'Could not connect') -gt 0 ]; then exit 1; fi;

--- a/bin/fpm-status.sh
+++ b/bin/fpm-status.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+# This is a helper script to assist in understanding long running (crashed) fpm processes.
+
+# This script will output details of all running processes e.g:
+
+# pid:                  146880
+# state:                Idle
+# start time:           27/Sep/2024:09:38:00 +0100
+# start since:          6
+# requests:             1
+# request duration:     1426
+# request method:       GET
+# request URI:          /app/mu-plugins/moj-auth/401.php
+# content length:       0
+# user:                 -
+# script:               /var/www/html/public/app/mu-plugins/moj-auth/401.php
+# last request cpu:     0.00
+# last request memory:  2097152
+
+env -i SCRIPT_NAME=/status SCRIPT_FILENAME=/status QUERY_STRING="full&html" REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock


### PR DESCRIPTION
This PR fixes syntax in `fpm-readiness.sh`, it also adds a helper script to get the status of fpm processes.