### PR TITLE
Update WP Document Revisions to fix JS WPDocumentRevisions is not defined.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "wpackagist-plugin/cms-tree-page-view": "*",
         "wpackagist-plugin/co-authors-plus": "*",
         "wpackagist-plugin/ewww-image-optimizer": "*",
-        "wpackagist-plugin/wp-document-revisions": "^3.5.0",
+        "wpackagist-plugin/wp-document-revisions": "^3.6.0",
         "wpackagist-plugin/simple-301-redirects":"2.0.9",
         "acf/advanced-custom-fields-pro": "*",
         "ministryofjustice/wp-rewrite-media-to-s3": "dev-php8-code-update",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae95797e9bf762423963b6cbe4e02ccc",
+    "content-hash": "ad7ff58b4cd4dbe4ed5e383179240838",
     "packages": [
         {
             "name": "acf/advanced-custom-fields-pro",
@@ -3434,15 +3434,15 @@
         },
         {
             "name": "wpackagist-plugin/wp-document-revisions",
-            "version": "3.5.0",
+            "version": "3.6.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/wp-document-revisions/",
-                "reference": "tags/3.5.0"
+                "reference": "tags/3.6.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/wp-document-revisions.3.5.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/wp-document-revisions.3.6.1.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
This PR should fix `WPDocumentRevisions is not defined` error.

![image](https://github.com/user-attachments/assets/976f8f17-6c41-466a-9c48-12b97ad1694f)
