### PR TITLE
Fix a bug in CloudFront signing and in fmp-status script.

### DIFF
--- a/bin/fpm-status.sh
+++ b/bin/fpm-status.sh
@@ -18,4 +18,4 @@
 # last request cpu:     0.00
 # last request memory:  2097152
 
-env -i SCRIPT_NAME=/status SCRIPT_FILENAME=/status QUERY_STRING="full&html" REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock
+env -i SCRIPT_NAME=/status SCRIPT_FILENAME=/status QUERY_STRING="full" REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock


### PR DESCRIPTION
For the status script, remove html from the query string, so that the output is in table layout.

For CloudFront, correctly decode the Policy cookie, from base64.

Prior to this fix, remainingTimeFromCookie was always returning 0, and issuing CF cookies on every request 🤦‍♂️