### PR TITLE
Add slack webhook secret for production namespace

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
           BASIC_AUTH_USER: ${{ secrets.BASIC_AUTH_USER }}
           BASIC_AUTH_PASS: ${{ secrets.BASIC_AUTH_PASS }}
           IGNORE_IP_RANGES: ${{ vars.IGNORE_IP_RANGES }}
+          ALERTS_SLACK_WEBHOOK: ${{ secrets.ALERTS_SLACK_WEBHOOK }}
         run: |
           ## - - - - - - - - - -
           ## CloudFront  - - - -


### PR DESCRIPTION
This PR fixes a bug where ALERTS_SLACK_WEBHOOK is an empty string when env vars are substituted in `deploy/production/secters.tpl.yml`