### PR TITLE
CDPT-2231 Explicitly set cookie paths to prevent conflicts in wp session cookies.

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -84,6 +84,10 @@ if (!env('WP_ENVIRONMENT_TYPE') && in_array(WP_ENV, ['production', 'staging', 'd
 Config::define('WP_HOME', env('WP_HOME'));
 Config::define('WP_SITEURL', env('WP_SITEURL'));
 Config::define('LOOPBACK_URL', env('LOOPBACK_URL') ?? 'http://127.0.0.1:8080');
+// Explicitly set cookie paths, to prevent conflicting wordpress_logged_in... wordpress_sec_... cookies.
+Config::define('COOKIEPATH', '/');
+Config::define('SITECOOKIEPATH', '/');
+Config::define('ADMIN_COOKIE_PATH', '/');
 
 /**
  * Custom Content Directory


### PR DESCRIPTION
Info in ticket: https://dsdmoj.atlassian.net/browse/CDPT-2231