### PR TITLE
Turn on debug log for all envs.

### DIFF
--- a/config/application.php
+++ b/config/application.php
@@ -173,7 +173,8 @@ Config::define('EWWWIO_WHITELABEL', true);
  * Debugging Settings
  */
 Config::define('WP_DEBUG_DISPLAY', false);
-Config::define('WP_DEBUG_LOG', false);
+Config::define('WP_DEBUG_LOG', true);
+Config::define('WP_DEBUG_LOG', '/dev/stderr');
 Config::define('SCRIPT_DEBUG', false);
 ini_set('display_errors', '0');
 // Additional logging for the authentication mu-plugin.


### PR DESCRIPTION
This is a reaction to seeing a 500 error on staging - having searched the logs, there was no indication of the cause.

This PR adds logging to `/dev/stderr`, it still does *not* display errors.