### PR TITLE
Update hpa.yml

### DIFF
--- a/deploy/production/hpa.yml
+++ b/deploy/production/hpa.yml
@@ -8,8 +8,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: intranet-production
-  minReplicas: 4
-  maxReplicas: 12
+  minReplicas: 5
+  maxReplicas: 18
   metrics:
     # fpm
     - type: ContainerResource

--- a/deploy/production/hpa.yml
+++ b/deploy/production/hpa.yml
@@ -18,10 +18,10 @@ spec:
         container: fpm
         target:
           type: Utilization
-          # If request is 500m let's early scale at 250m
+          # If request is 500m let's early scale at 200m
           # Rely on CPU usage for scaling more than memory usage.
           # For scaling down, CPU settles quickly and memory is freed up slowly.
-          averageUtilization: 50
+          averageUtilization: 40
     - type: ContainerResource
       containerResource:
         name: memory

--- a/deploy/production/hpa.yml
+++ b/deploy/production/hpa.yml
@@ -8,7 +8,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: intranet-production
-  minReplicas: 5
+  minReplicas: 6
   maxReplicas: 18
   metrics:
     # fpm


### PR DESCRIPTION
This PR:

- Increases the minimum replica count. It's a reaction to seeing spiky replica count graphs, and at least 5 replicas being spun up during business hours.
- Decreases the threshold of fpm CPU utilisation, my theory is that the fpm containers are returning 50x errors when their CPU is too high. Scaling earlier may help us avoid a 502 spike as seen in the below screenshots.

<img width="493" alt="image" src="https://github.com/user-attachments/assets/796a2b39-54e3-4911-a68e-a1491358bb21">

<img width="301" alt="image" src="https://github.com/user-attachments/assets/52baaf84-a9a7-4310-87c7-5a516dcf202a">
