### PR TITLE
Bug/CDPT-2258 Handle empty post and text domain. Add constructor to notify-for-wordpress

### DIFF
--- a/bin/composer-post-install.sh
+++ b/bin/composer-post-install.sh
@@ -43,3 +43,22 @@ if [ -f "$MOJ_COMPONENTS_FILE" ] ; then
   MOJ_COMPONENTS_CONTENT=$(perl -0777pe 's/'"$MOJ_COMPONENTS_SEARCH_PARAGRAPH"'/'"$MOJ_COMPONENTS_REPLACE_PARAGRAPH"'/s' "$MOJ_COMPONENTS_FILE")
   echo "$MOJ_COMPONENTS_CONTENT" > "$MOJ_COMPONENTS_FILE"
 fi
+
+
+NOTIFY_FILE=/var/www/html/public/app/plugins/notify-for-wordpress/inc/admin/class-dashboard-table.php
+NOTIFY_SEARCH="public function get_columns"
+NOTIFY_REPLACE='private \$plugin_text_domain;
+
+	public function __construct(string \$plugin_text_domain)
+	{ 
+		parent::__construct();
+		\$this->plugin_text_domain = \$plugin_text_domain;
+	}
+
+	public function get_columns'
+
+if [ -f "$NOTIFY_FILE" ] ; then
+  echo "Adding code blocke to notify-for-wordpress plugin"
+  NOTIFY_CONTENT=$(perl -0777pe 's/'"$NOTIFY_SEARCH"'/'"$NOTIFY_REPLACE"'/s' "$NOTIFY_FILE")
+  echo "$NOTIFY_CONTENT" > "$NOTIFY_FILE"
+fi

--- a/public/app/themes/clarity/inc/admin/plugins/co-authors-plus.php
+++ b/public/app/themes/clarity/inc/admin/plugins/co-authors-plus.php
@@ -156,7 +156,7 @@ if (function_exists('get_coauthors')) {
         global $post;
 
         // If the post does not have an error and is a guest-author post type.
-        if (!is_wp_error($post) && $post->post_type === 'guest-author') {
+        if (!is_wp_error($post) && $post?->post_type === 'guest-author') {
             return 'coauthors_wp_die_handler';
         }
 
@@ -173,11 +173,11 @@ if (function_exists('get_coauthors')) {
      * 
      * @param string $translated_text The translated text
      * @param string $text The original text
-     * @param string $domain The text domain
+     * @param ?string $domain The text domain
      * @return string The modified text
      */
 
-    function coauthors_filter_text(string $translated_text, string $text, string $domain): string
+    function coauthors_filter_text(string $translated_text, string $text, ?string $domain): string
     {
         if ($domain === 'co-authors-plus') {
             // Remove the string 'WordPress' from the plugin's text.


### PR DESCRIPTION
There is a bug where the [notify dashboard](http://intranet.docker/wp/wp-admin/index.php?page=notify-dashboard) was firing a fatal php error.

This was because the plugin was not setting the text-domain correctly. This has been fixed in the upstream git repo and a patch fix in this PR.

In a defensive programming move, `coauthors_filter_text` has been changed so that text domain is an optional string.

`$post?->post_type` should also fix the warning `Attempt to read property "post_type" on null`