### PR TITLE
Create a new deployment that handles cron tasks

### DIFF
--- a/deploy/development/deployment.tpl.yml
+++ b/deploy/development/deployment.tpl.yml
@@ -62,6 +62,167 @@ spec:
                   name: ${KUBE_NAMESPACE}-base64-secrets
                   key: IPS_FORMATTED
 
+        - name: fpm
+          image: ${ECR_URL}:${IMAGE_TAG_FPM}
+          resources:
+            limits:
+              # If a pod exceeds its CPU limit, Kubernetes will simply throttle the pod.
+              cpu: "4"
+              # If a pod exceeds its memory limit, Kubernetes will kill the pod.
+              memory: 2000Mi
+            requests:
+              cpu: 500m
+              memory: 600Mi
+          volumeMounts:
+            - name: uploads
+              mountPath: /var/www/html/public/app/uploads
+            - name: php-socket
+              mountPath: /sock
+          securityContext:
+            runAsUser: 101
+          # Check frequently during startup, so that scaling up can happen as fast as possible.
+          startupProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-readiness.sh
+            failureThreshold: 20
+            periodSeconds: 5
+          # Don't route traffic to this pod if the container is not ready.
+          readinessProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-readiness.sh
+            periodSeconds: 10
+            failureThreshold: 1
+          # Restart the container if it fails liveness script.
+          livenessProbe:
+            exec:
+              command:
+              - /usr/local/bin/fpm-health/fpm-liveness.sh
+            periodSeconds: 10
+          env:
+            - name: AWS_S3_BUCKET
+              valueFrom:
+                secretKeyRef:
+                  name: s3-bucket-output
+                  key: bucket_name
+            - name: AWS_CLOUDFRONT_PUBLIC_KEYS_OBJECT
+              valueFrom:
+                secretKeyRef:
+                  name: cloudfront-output
+                  key: cloudfront_public_keys
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: rds-output
+                  key: rds_instance_address
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: rds-output
+                  key: database_name
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: rds-output
+                  key: database_username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: rds-output
+                  key: database_password
+            - name: OPENSEARCH_URL
+              valueFrom:
+                secretKeyRef:
+                  name: central-digital-product-team-opensearch-proxy-url
+                  key: proxy_url
+            - name: BASIC_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: basic-auth-secret
+                  key: auth
+            - name: CACHE_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-output
+                  key: primary_endpoint_address
+            - name: CACHE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: elasticache-output
+                  key: auth_token
+          envFrom:
+            - configMapRef:
+                name: ${KUBE_NAMESPACE}
+            - secretRef:
+                name: ${KUBE_NAMESPACE}-secrets
+            - secretRef:
+                name: ${KUBE_NAMESPACE}-base64-secrets
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${KUBE_NAMESPACE}-cron
+  namespace: ${KUBE_NAMESPACE}
+  labels:
+    app: ${KUBE_NAMESPACE}-cron
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: ${KUBE_NAMESPACE}-cron
+  template:
+    metadata:
+      labels:
+        app: ${KUBE_NAMESPACE}-cron
+    spec:
+      volumes:
+        - name: uploads
+          emptyDir: { }
+        - name: php-socket
+          emptyDir: { }
+      terminationGracePeriodSeconds: 35
+      serviceAccountName: ${KUBE_NAMESPACE}-service
+      containers:
+        - name: nginx
+          image: ${ECR_URL}:${IMAGE_TAG_NGINX}
+          resources:
+            limits:
+              cpu: 500m
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 100Mi
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: uploads
+              mountPath: /var/www/html/public/app/uploads
+            - name: php-socket
+              mountPath: /sock
+          securityContext:
+            runAsUser: 101
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 8080
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 8080
+          env:
+            - name: IPS_FORMATTED
+              valueFrom:
+                secretKeyRef:
+                  name: ${KUBE_NAMESPACE}-base64-secrets
+                  key: IPS_FORMATTED
+
         - name: cron
           image: ${ECR_URL}:${IMAGE_TAG_CRON}
           resources:


### PR DESCRIPTION
The aim of this PR is to see if we can determint the root cause of CPU spikes that are happening on production.

By isolating cron tasks to a dedicated deployment, we can more easily see if it is a scheduled task that is causing the CPU spikes.

Steps to create the new deployment:

- Duplicated the existing deployment.
- The cron container is removed from the original deployment.
- The new deployment is named and labeled as `${KUBE_NAMESPACE}-cron`