### PR TITLE
fpm log slow queries and install `strace` on fpm containers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ ARG version_cron_alpine=3.19.1
 
 FROM ministryofjustice/wordpress-base-fpm:latest AS base-fpm
 
+RUN apk update && \
+    apk add strace
+
 # Make the Nginx user available in this container
 RUN addgroup -g 101 -S nginx; adduser -u 101 -S -D -G nginx nginx
 

--- a/deploy/config/php-pool.conf
+++ b/deploy/config/php-pool.conf
@@ -7,8 +7,8 @@ listen.owner = nginx;
 listen.group = nginx;
 listen.mode = 0660;
 
-ping.path=/ping
-ping.response=pong
+ping.path = /ping
+ping.response = pong
 
 pm = dynamic;
 pm.start_servers = 10;
@@ -17,6 +17,10 @@ pm.max_spare_servers = 20;
 pm.max_requests = 500;
 pm.max_children = 20;
 pm.status_path = /status;
+
+; Log a stack trace to stderr for slow queries.
+request_slowlog_timeout = 10s;
+slowlog = /proc/self/fd/2;
 
 [global]
 daemonize = no


### PR DESCRIPTION
Example output:

<img width="900" alt="image" src="https://github.com/user-attachments/assets/05681ec0-bed2-4d0f-93dd-df0d7110f4d4">
