### PR TITLE
Improve logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,12 @@ RUN rm zz-docker.conf && \
 ## Set our pool configuration
 COPY deploy/config/php-pool.conf pool.conf
 
+# Apend our relay config to the existing config file.
+RUN { \
+        echo 'relay.loglevel = error'; \
+        echo 'relay.logfile  = /dev/stderr'; \
+    } >> /usr/local/etc/php/conf.d/docker-php-ext-relay.ini
+
 WORKDIR /var/www/html
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,9 @@ RUN { \
         echo 'relay.logfile  = /dev/stderr'; \
     } >> /usr/local/etc/php/conf.d/docker-php-ext-relay.ini
 
+# Don't log every request.
+RUN perl -pi -e 's#^(?=access\.log\b)#;#' /usr/local/etc/php-fpm.d/docker.conf
+
 WORKDIR /var/www/html
 
 
@@ -126,9 +129,6 @@ RUN apk add zip
 WORKDIR /var/www/html
 
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
-
-# Don't leg every request.
-RUN perl -pi -e 's#^(?=access\.log\b)#;#' /usr/local/etc/php-fpm.d/docker.conf
 
 VOLUME ["/sock"]
 # nginx

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY deploy/config/php-pool.conf pool.conf
 
 # Apend our relay config to the existing config file.
 RUN { \
+        echo 'relay.maxmemory = 16M'; \
         echo 'relay.loglevel = error'; \
         echo 'relay.logfile  = /dev/stderr'; \
     } >> /usr/local/etc/php/conf.d/docker-php-ext-relay.ini

--- a/deploy/config/php-pool.conf
+++ b/deploy/config/php-pool.conf
@@ -23,6 +23,7 @@ request_slowlog_timeout = 10s;
 slowlog = /proc/self/fd/2;
 
 [global]
+log_buffering = false;
 daemonize = no
 emergency_restart_threshold = 10;
 emergency_restart_interval = 1m;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     volumes:
       - .:/var/www/html
       - php-socket:/sock
+      ### Deploy scripts
+      - ./deploy/config/php-pool.conf:/usr/local/etc/php-fpm.d/pool.conf
     env_file:
       - .env
     depends_on:

--- a/public/app/themes/clarity/functions.php
+++ b/public/app/themes/clarity/functions.php
@@ -113,6 +113,7 @@ require_once 'inc/relevanssi.php';
 require_once 'inc/shortcodes.php';
 require_once 'inc/security.php';
 require_once 'inc/table-modification.php';
+require_once 'inc/updates.php';
 require_once 'inc/uploads.php';
 require_once 'inc/whitelisted-emails.php';
 

--- a/public/app/themes/clarity/inc/updates.php
+++ b/public/app/themes/clarity/inc/updates.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace MOJ\Justice;
+
+/**
+ * Functions to related to updates, and disabling checks.
+ */
+class Updates
+{
+    public function __construct()
+    {
+        $this->hooks();
+    }
+
+    /**
+     * @return void
+     */
+    public function hooks(): void
+    {
+        /**
+         * Prevent http requests to api.wordpress.org to check for WP core versions.
+         * 
+         * Even though `AUTOMATIC_UPDATER_DISABLED` is set to true, we need to block
+         * requests api.wordpress.org to where WP checks for available versions.
+         * 
+         * This filter's function returns a dummy payload that will prevent an api request, 
+         * and not cause an error.
+         * 
+         * @see https://wp-kama.com/2020/disable-wp-updates-check
+         * @see https://developer.wordpress.org/reference/functions/wp_version_check/
+         */
+
+        add_filter(
+            'pre_site_transient_update_core',
+            fn() =>  (object) [
+                'updates' => [],
+                'version_checked' => $GLOBALS['wp_version'],
+                'last_checked' => time()
+            ]
+        );
+
+        /**
+         * Prevent http requests to api.wordpress.org to check for theme updates.
+         * 
+         * This filter's function returns a dummy payload that will prevent an api request,
+         * and not cause an error.
+         * 
+         * @see https://wp-kama.com/2020/disable-wp-updates-check
+         * @see https://developer.wordpress.org/reference/functions/wp_update_themes/
+         */
+
+        add_filter('pre_site_transient_update_themes', static function ($value) {
+            static $theme;
+
+            $theme || $theme = wp_get_theme('clarity');
+
+            return (object) [
+                'last_checked' => time(),
+                'checked' => [
+                    'clarity' => $theme->get('Version')
+                ]
+            ];
+        });
+    }
+}
+
+new Updates();

--- a/public/app/themes/clarity/inc/updates.php
+++ b/public/app/themes/clarity/inc/updates.php
@@ -29,7 +29,6 @@ class Updates
          * @see https://wp-kama.com/2020/disable-wp-updates-check
          * @see https://developer.wordpress.org/reference/functions/wp_version_check/
          */
-
         add_filter(
             'pre_site_transient_update_core',
             fn() =>  (object) [
@@ -48,7 +47,6 @@ class Updates
          * @see https://wp-kama.com/2020/disable-wp-updates-check
          * @see https://developer.wordpress.org/reference/functions/wp_update_themes/
          */
-
         add_filter('pre_site_transient_update_themes', static function ($value) {
             static $theme;
 
@@ -71,7 +69,6 @@ class Updates
          * @see https://wp-kama.com/2020/disable-wp-updates-check
          * @see https://developer.wordpress.org/reference/functions/wp_update_plugins/
          */
-
         add_filter('pre_site_transient_update_plugins', static function ($value) {
             static $plugins;
             $plugins || $plugins = get_plugins();

--- a/public/app/themes/clarity/inc/updates.php
+++ b/public/app/themes/clarity/inc/updates.php
@@ -40,7 +40,7 @@ class Updates
         );
 
         /**
-         * Prevent http requests to api.wordpress.org to check for theme updates.
+         * Prevent http requests to api.wordpress.org to check for theme version.
          * 
          * This filter's function returns a dummy payload that will prevent an api request,
          * and not cause an error.
@@ -60,6 +60,32 @@ class Updates
                     'clarity' => $theme->get('Version')
                 ]
             ];
+        });
+
+        /**
+         * Prevent http requests to api.wordpress.org to check for plugin versions.
+         * 
+         * This filter's function returns a dummy payload that will prevent an api request,
+         * and not cause an error.
+         * 
+         * @see https://wp-kama.com/2020/disable-wp-updates-check
+         * @see https://developer.wordpress.org/reference/functions/wp_update_plugins/
+         */
+
+        add_filter('pre_site_transient_update_plugins', static function ($value) {
+            static $plugins;
+            $plugins || $plugins = get_plugins();
+
+            $return_value = (object) [
+                'last_checked' => time(),
+                'checked' => []
+            ];
+
+            foreach ($plugins as $file => $p) {
+                $return_value->checked[$file] = $p['Version'];
+            }
+
+            return $return_value;
         });
     }
 }


### PR DESCRIPTION
- Log Relay (Redis) errors to stderr.
  A note on memory limit: https://relay.so/docs/1.x/configuration#memory-limits
- fpm to not log every request, it's makes the logs too noisy.
- Filter out known hosts from pre_http_request logging - to remove noise from the logs.
- Prevent API requests for core, theme and plugin versions.