### PR TITLE
CDPT-2264 Add a timeout to the fpm readiness script, plus...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,11 +72,11 @@ RUN RELAY_CONFIG_FILE=/usr/local/etc/php/conf.d/docker-php-ext-relay.ini && \
     ## Eviction policy: lru. Evicts the least recently used keys out of all keys when relay.maxmemory_pct is reached
     sed -i 's/^;\? \?relay.eviction_policy =.*/relay.eviction_policy = lru/' $RELAY_CONFIG_FILE && \
     ## Start evicting keys when 90% of the memory is used.
-    sed -i 's/^;\? \?relay.maxmemory_pct =.*/relay.maxmemory_pct = 90/' $RELAY_CONFIG_FILE && \
+    sed -i 's/^;\? \?relay.maxmemory_pct =.*/relay.maxmemory_pct = 75/' $RELAY_CONFIG_FILE && \
     ## Set the session compression to lz4
     sed -i 's/^;\? \?relay.session.compression =.*/relay.session.compression = lz4/' $RELAY_CONFIG_FILE && \
     ## Set the session compression level to 1
-    sed -i 's/^;\? \?relay.session.compression_level =.*/relay.session.compression_level = 1/' $RELAY_CONFIG_FILE
+    sed -i 's/^;\? \?relay.session.compression_level =.*/relay.session.compression_level = 3/' $RELAY_CONFIG_FILE
     
 
 # Don't log every request.

--- a/bin/fpm-readiness.sh
+++ b/bin/fpm-readiness.sh
@@ -28,7 +28,7 @@ if [ $(echo "$PING_RESPONSE" | tail -1) != 'pong' ]; then exit 1; fi;
 
 
 # 2️⃣ Request the fpm status via fast-cgi.
-FPM_STATUS=$(env -i SCRIPT_NAME=/status SCRIPT_FILENAME=/status REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock);
+FPM_STATUS=$(env -i SCRIPT_NAME=/status SCRIPT_FILENAME=/status REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock &);
 
 # Store the process ID of the status request.
 STATUS_PID=$!;

--- a/bin/fpm-readiness.sh
+++ b/bin/fpm-readiness.sh
@@ -51,20 +51,3 @@ wait $STATUS_PID;
 
 # Exit with code 1 if the status is 'Could not connect to /sock/fpm.sock'.
 if [ "$(echo "$FPM_STATUS" | grep -c 'Could not connect')" -gt 0 ]; then exit 1; fi;
-
-
-# How do I run a script once every 200ms 1000 times in shell?
-# Like so
-for i in $(seq 1 10000); do
-    # Run the script
-    /usr/local/bin/fpm-health/fpm-readiness.sh
-    # Get the exit code
-    exit_code=$?
-    # If the exit code is non 0, break the loop
-    if [ $exit_code -ne 0 ]; then
-        break
-    fi
-    # Wait 200ms
-    sleep 0.001
-    echo "Attempt $i"
-done

--- a/bin/fpm-readiness.sh
+++ b/bin/fpm-readiness.sh
@@ -1,13 +1,70 @@
 #!/usr/bin/env ash
 
-# Send a ping request via fast-cgi. Use an empty environment with `env -i`.
-PING_RESPONSE=$(env -i SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock | tail -1);
+# 1️⃣ Send a ping request via fast-cgi. Use an empty environment with `env -i`.
+PING_RESPONSE=$(env -i SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock | tail -1 &);
+
+# Store the process ID of the ping request.
+PING_PID=$!;
+
+# Wait for 1 second to give the ping request time to complete.
+sleep 1;
+
+# Check if the ping request is still running.
+if kill -0 $PING_PID 2>/dev/null; then
+    # If the ping request is still running, terminate it.
+    kill $PING_PID;
+    # Print an error message.
+    echo "Ping request timed out.";
+    # Exit with code 1.
+    exit 1;
+fi;
+
+# Wait for the ping request process to complete.
+wait $PING_PID;
 
 # Exit with code 1 if the ping response was not 'pong'.
 if [ "$PING_RESPONSE" != 'pong' ]; then exit 1; fi;
 
-# Request the fpm status via fast-cgi.
+
+
+# 2️⃣ Request the fpm status via fast-cgi.
 FPM_STATUS=$(env -i SCRIPT_NAME=/status SCRIPT_FILENAME=/status REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock);
+
+# Store the process ID of the status request.
+STATUS_PID=$!;
+
+# Wait for 1 second to give the status request time to complete.
+sleep 1;
+
+# Check if the status request is still running.
+if kill -0 $STATUS_PID 2>/dev/null; then
+    # If the status request is still running, terminate it.
+    kill $STATUS_PID;
+    # Print an error message.
+    echo "Status request timed out.";
+    # Exit with code 1.
+    exit 1;
+fi;
+
+# Wait for the status request process to complete.
+wait $STATUS_PID;
 
 # Exit with code 1 if the status is 'Could not connect to /sock/fpm.sock'.
 if [ "$(echo "$FPM_STATUS" | grep -c 'Could not connect')" -gt 0 ]; then exit 1; fi;
+
+
+# How do I run a script once every 200ms 1000 times in shell?
+# Like so
+for i in $(seq 1 10000); do
+    # Run the script
+    /usr/local/bin/fpm-health/fpm-readiness.sh
+    # Get the exit code
+    exit_code=$?
+    # If the exit code is non 0, break the loop
+    if [ $exit_code -ne 0 ]; then
+        break
+    fi
+    # Wait 200ms
+    sleep 0.001
+    echo "Attempt $i"
+done

--- a/bin/fpm-readiness.sh
+++ b/bin/fpm-readiness.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env ash
 
 # 1️⃣ Send a ping request via fast-cgi. Use an empty environment with `env -i`.
-PING_RESPONSE=$(env -i SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock | tail -1 &);
+PING_RESPONSE=$(env -i SCRIPT_NAME=/ping SCRIPT_FILENAME=/ping REQUEST_METHOD=GET cgi-fcgi -bind -connect /sock/fpm.sock &);
 
 # Store the process ID of the ping request.
 PING_PID=$!;
@@ -23,7 +23,7 @@ fi;
 wait $PING_PID;
 
 # Exit with code 1 if the ping response was not 'pong'.
-if [ "$PING_RESPONSE" != 'pong' ]; then exit 1; fi;
+if [ $(echo "$PING_RESPONSE" | tail -1) != 'pong' ]; then exit 1; fi;
 
 
 

--- a/composer.json
+++ b/composer.json
@@ -100,7 +100,6 @@
                 "ministryofjustice/php-markdown-extra",
                 "wpackagist-plugin/wp-document-revisions",
                 "wpackagist-plugin/elasticpress",
-                "wpackagist-plugin/ewww-image-optimizer",
                 "wpengine/advanced-custom-fields-pro"
             ],
             "public/app/plugins/{$name}/": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5763ec9935ee3ceff6c57f2a16b70920",
+    "content-hash": "72e8d00584ac1127269d674a0f7a177c",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -3155,15 +3155,15 @@
         },
         {
             "name": "wpackagist-plugin/ewww-image-optimizer",
-            "version": "7.9.0",
+            "version": "7.9.1",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/ewww-image-optimizer/",
-                "reference": "tags/7.9.0"
+                "reference": "tags/7.9.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/ewww-image-optimizer.7.9.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/ewww-image-optimizer.7.9.1.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"
@@ -3357,6 +3357,6 @@
         "ext-posix": "*",
         "ext-zlib": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/public/app/themes/clarity/functions.php
+++ b/public/app/themes/clarity/functions.php
@@ -126,3 +126,56 @@ new MOJ\Intranet\WPElasticPress();
 $search = new MOJ\Intranet\Search();
 $search->hooks();
 
+/**
+ * Add logging on potential causes of high CPU usage
+ */
+
+// Log on document_serve
+add_action('document_serve', function ($file, $post_id, $attach_id) {
+    error_log('CDPT_Debug: document_serve: ' . $file . ' ' . $post_id . ' ' . $attach_id);
+}, 10, 3);
+
+// Log on document_serve_done
+add_action('document_serve_done', function ($file, $attach_id ) {
+    error_log('CDPT_Debug: document_serve_done: ' . $file . ' ' . $attach_id);
+}, 10, 2);
+
+// Log on document edit
+add_action('document_edit', function () {
+    error_log('CDPT_Debug: document_edit');
+}, 10);
+
+// Log on document saved
+add_action('document_saved', function ($doc_id, $attach_id) {
+    error_log('CDPT_Debug: document_saved: ' . $doc_id . ' ' . $attach_id);
+}, 10, 2);
+
+// Log on attachment upload
+add_action('add_attachment', function ($attach_id) {
+    error_log('CDPT_Debug: add_attachment: ' . $attach_id);
+}, 10, 1);
+
+// Log on edit post
+add_action('edit_post', function ($post_id) {
+    error_log('CDPT_Debug: edit_post: ' . $post_id);
+}, 10, 1);
+
+// Log on post save
+add_action('save_post', function ($post_id) {
+    error_log('CDPT_Debug: save_post: ' . $post_id);
+}, 10, 1);
+
+// Log on S3 upload - as3cf_post_upload_attachment
+add_action('as3cf_post_upload_attachment', function ($source_id, $item) {
+    error_log('CDPT_Debug: as3cf_post_upload_attachment: ' . $source_id);
+}, 10, 3);
+
+// Log on as3cf_pre_upload_object
+add_action('as3cf_pre_upload_object', function ($args) {
+    error_log('CDPT_Debug: as3cf_pre_upload_object');
+}, 10, 1);
+
+// Log on as3cf_post_upload_item
+add_action('as3cf_post_upload_item', function ($item) {
+    error_log('CDPT_Debug: as3cf_post_upload_item');
+}, 10, 1);

--- a/public/app/themes/clarity/inc/post-types/event.php
+++ b/public/app/themes/clarity/inc/post-types/event.php
@@ -127,6 +127,9 @@ add_action( 'save_post_event', 'mojintranet_clear_events_cache', 10, 0);
 
 // Delete `event_get_events_...` transients from the database, these are created in EventsHelper.
 function mojintranet_clear_events_cache() {
+
+    error_log('Clearing event cache.');
+
     global $wpdb;
     $wpdb->query( "DELETE FROM `$wpdb->options` WHERE `option_name` LIKE ('_transient_event_get_events_%')" );
 


### PR DESCRIPTION
This PR means that even when the fpm server is not responding via the socket - the script will still `exit 1` rather than hang.

It also includes:

- Changes to Relay config, aiming to prevent the OOM error.
- A move of the `ewww-image-optimizer` plugin from `mu-plugins` so that we can trial disabling it.