### PR TITLE
CDPT-2264 Fix font assets, and debug logging typo.

### DIFF
--- a/public/app/themes/clarity/functions.php
+++ b/public/app/themes/clarity/functions.php
@@ -131,9 +131,9 @@ $search->hooks();
  */
 
 // Log on document_serve
-/*add_action('document_serve', function ($file, $post_id, $attach_id) {
-    error_log('CDPT_Debug: document_serve: ' . $file . ' ' . $post_id . ' ' . $attach_id);
-}, 10, 3);
+add_action('serve_document', function ( $post_id, $file ) {
+    error_log('CDPT_Debug: document_serve: ' . $post_id . ' ' . $file);
+}, 10, 2);
 
 // Log on document_serve_done
 add_action('document_serve_done', function ($file, $attach_id ) {
@@ -143,39 +143,39 @@ add_action('document_serve_done', function ($file, $attach_id ) {
 // Log on document edit
 add_action('document_edit', function () {
     error_log('CDPT_Debug: document_edit');
-}, 10);
+});
 
 // Log on document saved
 add_action('document_saved', function ($doc_id, $attach_id) {
     error_log('CDPT_Debug: document_saved: ' . $doc_id . ' ' . $attach_id);
-}, 10, 2);*/
+}, 10, 2);
 
 // Log on attachment upload
 add_action('add_attachment', function ($attach_id) {
     error_log('CDPT_Debug: add_attachment: ' . $attach_id);
-}, 10, 1);
+});
 
 // Log on edit post
 add_action('edit_post', function ($post_id) {
     error_log('CDPT_Debug: edit_post: ' . $post_id);
-}, 10, 1);
+});
 
 // Log on post save
 add_action('save_post', function ($post_id) {
     error_log('CDPT_Debug: save_post: ' . $post_id);
-}, 10, 1);
+});
 
 // Log on S3 upload - as3cf_post_upload_attachment
 add_action('as3cf_post_upload_attachment', function ($source_id, $item) {
     error_log('CDPT_Debug: as3cf_post_upload_attachment: ' . $source_id);
-}, 10, 3);
+}, 10, 2);
 
 // Log on as3cf_pre_upload_object
-add_action('as3cf_pre_upload_object', function ($args) {
+add_action('as3cf_pre_upload_object', function ($args, $file) {
     error_log('CDPT_Debug: as3cf_pre_upload_object');
-}, 10, 1);
+}, 10, 2);
 
 // Log on as3cf_post_upload_item
 add_action('as3cf_post_upload_item', function ($item) {
     error_log('CDPT_Debug: as3cf_post_upload_item');
-}, 10, 1);
+});

--- a/public/app/themes/clarity/inc/amazon-s3-and-cloudfront-assets.php
+++ b/public/app/themes/clarity/inc/amazon-s3-and-cloudfront-assets.php
@@ -202,8 +202,8 @@ class AmazonS3AndCloudFrontAssets
         }
 
         // Fonts cannot be served via the CDN, because browsers do not send cookies for `@font-face` requests.
-        // Exclude the core-css and style handles from being rewritten, because they use `@font-face`.
-        if (in_array($handle, ['core-css', 'style'])) {
+        // Exclude the core-css handle from being rewritten, because it uses `@font-face`.
+        if (in_array($handle, ['core-css'])) {
             return $src;
         }
 

--- a/public/app/themes/clarity/inc/post-types/event.php
+++ b/public/app/themes/clarity/inc/post-types/event.php
@@ -128,8 +128,8 @@ add_action( 'save_post_event', 'mojintranet_clear_events_cache', 10, 0);
 // Delete `event_get_events_...` transients from the database, these are created in EventsHelper.
 function mojintranet_clear_events_cache() {
 
-    error_log('Clearing event cache.');
-
+    error_log('CDPT_Debug: Clearing event cache.');
+    
     global $wpdb;
     $wpdb->query( "DELETE FROM `$wpdb->options` WHERE `option_name` LIKE ('_transient_event_get_events_%')" );
 
@@ -138,4 +138,6 @@ function mojintranet_clear_events_cache() {
         // As there is no function to clear cache by 'keys that start with', we have to flush the whole cache.
         wp_cache_flush();
     }
+
+    error_log('CDPT_Debug: Cleared event cache.');
 }

--- a/public/app/themes/clarity/src/globals/css/fonts.styl
+++ b/public/app/themes/clarity/src/globals/css/fonts.styl
@@ -10,3 +10,14 @@
   src: url("../fonts/nta_bold.woff") format("woff");
   font-weight: bold;
 }
+
+@font-face {
+  font-family: 'moji-clarity';
+  src:  url('../fonts/moji-clarity.eot?vklv4a');
+  src:  url('../fonts/moji-clarity.eot?vklv4a#iefix') format('embedded-opentype'),
+    url('../fonts/moji-clarity.ttf?vklv4a') format('truetype'),
+    url('../fonts/moji-clarity.woff?vklv4a') format('woff'),
+    url('../fonts/moji-clarity.svg?vklv4a#moji-clarity') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}

--- a/public/app/themes/clarity/src/globals/css/icons.styl
+++ b/public/app/themes/clarity/src/globals/css/icons.styl
@@ -1,14 +1,3 @@
-@font-face {
-  font-family: 'moji-clarity';
-  src:  url('../fonts/moji-clarity.eot?vklv4a');
-  src:  url('../fonts/moji-clarity.eot?vklv4a#iefix') format('embedded-opentype'),
-    url('../fonts/moji-clarity.ttf?vklv4a') format('truetype'),
-    url('../fonts/moji-clarity.woff?vklv4a') format('woff'),
-    url('../fonts/moji-clarity.svg?vklv4a#moji-clarity') format('svg');
-  font-weight: normal;
-  font-style: normal;
-}
-
 .u-icon {
   /* use !important to prevent issues with browser extensions that change fonts */
   font-family: 'moji-clarity' !important;


### PR DESCRIPTION
This PR includes 2 changes.

- I've noticed that prior to the CPU spikes on FPM containers, in 5 cases there has been requests to font files that nginx could not find. This results in logs like:

```
2024/11/20 13:23:04 [error] 25#25: *138 open() "/var/www/html/public/app/themes/clarity/dist/globals/fonts/moji-clarity.woff" failed (2: No such file or directory), client: 172.20.201.206, server: localhost, request: "GET /app/themes/clarity/dist/globals/fonts/moji-clarity.woff?vklv4a HTTP/1.1", host: "intranet.justice.gov.uk", referrer: "https://intranet.justice.gov.uk/app/themes/clarity/dist/css/style.css"
2024/11/20 13:23:12 [error] 23#23: *57 open() "/var/www/html/public/app/themes/clarity/dist/globals/fonts/moji-clarity.woff" failed (2: No such file or directory), client: 172.20.173.150, server: localhost, request: "GET /app/themes/clarity/dist/globals/fonts/moji-clarity.woff?vklv4a HTTP/1.1", host: "intranet.justice.gov.uk", referrer: "https://intranet.justice.gov.uk/app/themes/clarity/dist/css/style.css"
2024/11/20 13:23:15 [error] 22#22: *17 open() "/var/www/html/public/app/themes/clarity/dist/globals/fonts/moji-clarity.ttf" failed (2: No such file or directory), client: 172.20.173.150, server: localhost, request: "GET /app/themes/clarity/dist/globals/fonts/moji-clarity.ttf?vklv4a HTTP/1.1", host: "intranet.justice.gov.uk", referrer: "https://intranet.justice.gov.uk/app/themes/clarity/dist/css/style.css"
2024/11/20 13:23:58 [error] 23#23: *962 open() "/var/www/html/public/app/themes/clarity/dist/globals/fonts/moji-clarity.woff" failed (2: No such file or directory), client: 172.20.133.161, server: localhost, request: "GET /app/themes/clarity/dist/globals/fonts/moji-clarity.woff?vklv4a HTTP/1.1", host: "intranet.justice.gov.uk", referrer: "https://intranet.justice.gov.uk/app/themes/clarity/dist/css/style.css"
```

The font files in question are not at `/dist/globals/fonts/moji-clarity.woff` but `/dist/fonts/moji-clarity.woff` without globals in the name.

I noticed that the path is correct in `https://intranet.justice.gov.uk/app/themes/clarity/dist/css/globals.css` but incorrct in `https://intranet.justice.gov.uk/app/themes/clarity/dist/css/style.css`

I also noticed that `globals.css` and `style.css` are both loaded on all frontend pages.

The fix is to move the `@font-family` css statement to `fonts.styl`, so that it is included only in `globals.css` and with the correct path.

---

The 2nd fix is to debug logging, there was an error because I typed `document_serve`  instead of `serve_document`. The former is a filter and the latter is an action. This has been addressed and the add_action parameters have also been tidied up.
