### PR TITLE
CDPT-2264 Improve nginx's file serving.

### DIFF
--- a/deploy/config/local/nginx/server.conf
+++ b/deploy/config/local/nginx/server.conf
@@ -71,8 +71,14 @@ server {
 
     # Empty location blocks to allow access when "/" location
     # sends an HTTP 503 during maintenance mode
-    location /app/themes/clarity/error-pages/ { }
-    location /app/themes/clarity/dist/ { }
+    location /app/themes/clarity/error-pages/ {
+        # If the file exists, serve it directly, else return 404.
+        try_files $uri =404;
+    }
+    location /app/themes/clarity/dist/ {
+        # If the file exists, serve it directly, else return 404.
+        try_files $uri =404;
+    }
 
     # Rewrite old upload URLs to the bedrock equivalent
     location /wp-content/uploads/ {

--- a/deploy/config/server.conf
+++ b/deploy/config/server.conf
@@ -90,8 +90,14 @@ server {
 
     # Empty location blocks to allow access when "/" location
     # sends an HTTP 503 during maintenance mode
-    location /app/themes/clarity/error-pages/ { }
-    location /app/themes/clarity/dist/ { }
+    location /app/themes/clarity/error-pages/ {
+        # If the file exists, serve it directly, else return 404.
+        try_files $uri =404;
+    }
+    location /app/themes/clarity/dist/ {
+        # If the file exists, serve it directly, else return 404.
+        try_files $uri =404;
+    }
 
     # Rewrite old upload URLs to the bedrock equivalent
     location /wp-content/uploads/ {


### PR DESCRIPTION
Previously a missing file caused an error. Now it's a 404 without an error.

Before:

```
[error] 30#30: *22939 open() "/var/www/html/public/app/themes/clarity/dist/globals/fonts/moji-clarity.ttf" failed (2: No such file or directory), client: 172.20.163.241, server: localhost, request: "GET /app/themes/clarity/dist/globals/fonts/moji-clarity.ttf?vklv4a HTTP/1.1", host: "intranet.justice.gov.uk", referrer: "https://intranet.justice.gov.uk/app/themes/clarity/dist/css/style.css?id=403678736ef4bf78b9131a99ad902082"
```

After:

```
172.21.0.8 - - [20/Nov/2024:16:19:12 +0000] "GET /app/themes/clarity/dist/globals/fonts/moji-clarity.ttf HTTP/1.1" 404 1375 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36" "192.168.65.1"
```