### PR TITLE
Add error description to OAuth callback errors.

### DIFF
--- a/public/app/mu-plugins/moj-auth/traits/oauth.php
+++ b/public/app/mu-plugins/moj-auth/traits/oauth.php
@@ -175,6 +175,7 @@ trait AuthOauth
             $access_token = $oauth_client->getAccessToken('authorization_code', ['code' => $_GET['code']]);
         } catch (IdentityProviderException $e) {
             $this->log('Error: ' . $e->getMessage(), null, 'error');
+            $this->log('Error response body: ', $e->getResponseBody(), 'error');
             http_response_code(401) && exit();
         }
 


### PR DESCRIPTION
This PR will give us better logging to diagnose OAuth related errors.

Before: 

```
[15-Jan-2025 11:07:12 UTC] MOJ_AUTH: Error: invalid_grant 
```

After:

```
[15-Jan-2025 11:07:12 UTC] MOJ_AUTH: Error: invalid_grant 
[15-Jan-2025 11:07:12 UTC] MOJ_AUTH: Error:  Array
(
    [error] => invalid_grant
    [error_description] => AADSTS9002313: Invalid request. Request is malformed or invalid. Trace ID: 12e93405-8f34-4be2-9965-9b4780501100 Correlation ID: 27d90d53-2997-456b-8065-923945891271 Timestamp: 2025-01-15 11:07:12Z
    [error_codes] => Array
        (
            [0] => 9002313
        )
    [timestamp] => 2025-01-15 11:07:12Z
    [trace_id] => 8f34-4be2-9965
    [correlation_id] => 2997-456b-8065
    [error_uri] => https://login.microsoftonline.com/error?code=9002313
)
```