### PR TITLE
CDPT-2265 wp-document-revisions - correct the most recent revision author

### DIFF
--- a/bin/composer-post-install.sh
+++ b/bin/composer-post-install.sh
@@ -57,7 +57,7 @@ if [ -f "$MOJ_COMPONENTS_FILE" ] ; then
 fi
 
 
-NOTIFY_FILE=/var/www/html/public/app/plugins/notify-for-wordpress/inc/admin/class-dashboard-table.php
+NOTIFY_FILE=/var/www/html/public/app/mu-plugins/notify-for-wordpress/inc/admin/class-dashboard-table.php
 NOTIFY_SEARCH="public function get_columns"
 NOTIFY_REPLACE='private \$plugin_text_domain;
 
@@ -84,4 +84,24 @@ TREE_VIEW_REPLACE="htmlspecialchars_decode(\$editLink ?? '')"
 if grep -q  $TREE_VIEW_SEARCH $TREE_VIEW_FILE ; then
   echo "Fixing warning in cms-tree-page-view..."
   sed -i "s/$TREE_VIEW_SEARCH/$TREE_VIEW_REPLACE/g" $TREE_VIEW_FILE
+fi
+
+# Check that the version of wp-document-revisions is ont that's been confirmed to work.
+verify_composer_package_version "wpackagist-plugin/wp-document-revisions" "3.6.1"
+
+DOCUMENT_REVISIONS_FILE=/var/www/html/public/app/mu-plugins/wp-document-revisions/includes/class-wp-document-revisions-admin.php
+
+DOCUMENT_REVISIONS_SEARCH_1="\$revisions    = \$this->get_revisions( \$post->ID );"
+DOCUMENT_REVISIONS_REPLACE_1="\$revisions    = apply_filters('wp_document_revisions_get_revisions', \$this->get_revisions( \$post->ID ), 'document_metabox');"
+
+DOCUMENT_REVISIONS_SEARCH_2="\$latest_version = \$this->get_latest_revision( \$post->ID );"
+DOCUMENT_REVISIONS_REPLACE_2="\$latest_version = apply_filters('wp_document_revisions_get_latest_revision', \$this->get_latest_revision( \$post->ID ), 'document_metabox');"
+
+# If the file exists, then replace the search strings.
+if [ -f "$DOCUMENT_REVISIONS_FILE" ] ; then
+  echo "Adding wp_document_revisions_get_revisions filter to wp-document-revisions..."
+  sed -i "s/$DOCUMENT_REVISIONS_SEARCH_1/$DOCUMENT_REVISIONS_REPLACE_1/g" $DOCUMENT_REVISIONS_FILE
+
+  echo "Adding wp_document_revisions_get_latest_revision filter to wp-document-revisions..."
+  sed -i "s/$DOCUMENT_REVISIONS_SEARCH_2/$DOCUMENT_REVISIONS_REPLACE_2/g" $DOCUMENT_REVISIONS_FILE
 fi

--- a/public/app/themes/clarity/inc/admin/plugins/wp-document-revisions.php
+++ b/public/app/themes/clarity/inc/admin/plugins/wp-document-revisions.php
@@ -192,8 +192,11 @@ class WPDocumentRevisions
         }
 
         // If we don't have a post ID, but we are in the loop, get the post ID.
-        if (!$post_id && get_the_ID()) {
-            $post_id = get_the_ID();
+        $post_id = $post_id ?: get_the_ID();
+
+        // If we still don't have a post ID, return 0.
+        if (!$post_id) {
+            return 0;
         }
 
         // If we haven't already set the wp_document_revisions object, do so now.
@@ -202,7 +205,7 @@ class WPDocumentRevisions
         }
 
         // Get the revisions for the current post - the first in the array is the document, technically not a revision.
-        $document_revisions = $this->wp_document_revisions->get_revisions(get_the_ID());
+        $document_revisions = $this->wp_document_revisions->get_revisions($post_id);
 
         // In an edge case we might not have any revisions. If so, return 0.
         if (empty($document_revisions)) {
@@ -231,11 +234,11 @@ class WPDocumentRevisions
      * When this filter is called in the context of 'revision_metabox',
      * it is used to correct the author on the first row of the revisions table.
      *
-     * @param array $revisions The revisions.
+     * @param false|array $revisions The revisions.
      * @param string $context The context.
-     * @return array The filtered revisions.
+     * @return false|array The filtered revisions.
      */
-    public function filterGetMostRecentRevision($revisions, $context)
+    public function filterGetMostRecentRevision($revisions, string $context)
     {
         if ('revision_metabox' !== $context) {
             return $revisions;
@@ -256,11 +259,11 @@ class WPDocumentRevisions
      * When this filter is called in the context of 'document_metabox',
      * it is used to correct the author in the string 'Checked in x ago by y'.
      * 
-     * @param mixed $revision The revision.
+     * @param false|WP_Post $revision The revision.
      * @param string $context The context.
-     * @return mixed The filtered revision.
+     * @return false|WP_Post The filtered revision.
      */
-    public function filterGetLatestRevision(mixed $revision, string $context): mixed
+    public function filterGetLatestRevision($revision, string $context)
     {
         if ('document_metabox' !== $context) {
             return $revision;

--- a/public/app/themes/clarity/inc/admin/plugins/wp-document-revisions.php
+++ b/public/app/themes/clarity/inc/admin/plugins/wp-document-revisions.php
@@ -46,7 +46,7 @@ class WPDocumentRevisions
         // Filter to retry missing files.
         add_filter('get_attached_file', [$this, 'retryFilesNotFound'], 15, 2);
         // Filter the document get_revisions result to correct the author.
-        add_filter('wp_document_revisions_get_revisions', [$this, 'filterGetMostRecentRevisionAuthor'], 10, 2);
+        add_filter('wp_document_revisions_get_revisions', [$this, 'filterGetMostRecentRevision'], 10, 2);
         // Filter the get_latest_revision result to correct the author.
         add_filter('wp_document_revisions_get_latest_revision', [$this, 'filterGetLatestRevision'], 10, 2);
     }
@@ -227,12 +227,15 @@ class WPDocumentRevisions
 
     /**
      * Filter the get_revisions result to correct the author.
-     * 
+     *
+     * When this filter is called in the context of 'revision_metabox',
+     * it is used to correct the author on the first row of the revisions table.
+     *
      * @param array $revisions The revisions.
      * @param string $context The context.
      * @return array The filtered revisions.
      */
-    public function filterGetMostRecentRevisionAuthor($revisions, $context)
+    public function filterGetMostRecentRevision($revisions, $context)
     {
         if ('revision_metabox' !== $context) {
             return $revisions;
@@ -249,6 +252,9 @@ class WPDocumentRevisions
 
     /**
      * Filter the get_latest_revision result to correct the author.
+     * 
+     * When this filter is called in the context of 'document_metabox',
+     * it is used to correct the author in the string 'Checked in x ago by y'.
      * 
      * @param mixed $revision The revision.
      * @param string $context The context.


### PR DESCRIPTION
Reluctantly, I had to use composer-post-install.sh script to fix this bug.

The script adds 2 filters to wp-document-revisions functions.

These filters are then used in the theme to correct the author name in 2 places on the document edit screen.