### PR TITLE
CDPT-2574 Remove the phpredis class as it's will be added to the base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,6 @@ FROM ministryofjustice/wordpress-base-fpm:latest AS base-fpm
 RUN apk update && \
     apk add strace
 
-# Temporarily install phpredis here. With potential to move to wordpress-base-image.
-# See https://github.com/phpredis/phpredis
-RUN apk add --no-cache pcre-dev $PHPIZE_DEPS \
-    && pecl install redis \
-    && docker-php-ext-enable redis.so
-
-RUN apk del pcre-dev $PHPIZE_DEPS
-
 # Make the Nginx user available in this container
 RUN addgroup -g 101 -S nginx; adduser -u 101 -S -D -G nginx nginx
 


### PR DESCRIPTION
Don't merge (and deploy) until https://github.com/ministryofjustice/wordpress-base-fpm/pull/31 has been merged and built.