### PR TITLE
CDPT-2601 Downgrade to WP Media Offload Lite

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,8 @@
         "php-http/guzzle7-adapter": "^1.0",
         "microsoft/kiota-authentication-phpleague": "^1.3",
         "microsoft/kiota-http-guzzle": "^1.1",
-        "microsoft/kiota-abstractions": "^1.0"
+        "microsoft/kiota-abstractions": "^1.0",
+        "deliciousbrains/wp-amazon-s3-and-cloudfront": "^3.2"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.0.2",
@@ -100,7 +101,6 @@
         "installer-paths": {
             "public/app/mu-plugins/{$name}/": [
                 "type:wordpress-muplugin",
-                "deliciousbrains-plugin/wp-offload-media",
                 "ministryofjustice/wp-moj-elasticsearch",
                 "ministryofjustice/php-markdown-extra",
                 "wpackagist-plugin/wp-document-revisions",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e83f22005bd32f6f95a9278497c0a4c6",
+    "content-hash": "b1e965e73f9251d61ce6905fa9563b03",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -590,6 +590,45 @@
             "extra": {
                 "installer-name": "amazon-s3-and-cloudfront-pro"
             }
+        },
+        {
+            "name": "deliciousbrains/wp-amazon-s3-and-cloudfront",
+            "version": "3.2.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/deliciousbrains/wp-amazon-s3-and-cloudfront.git",
+                "reference": "c6a44528c93586be89296b592c918fb3b87b8c15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/deliciousbrains/wp-amazon-s3-and-cloudfront/zipball/c6a44528c93586be89296b592c918fb3b87b8c15",
+                "reference": "c6a44528c93586be89296b592c918fb3b87b8c15",
+                "shasum": ""
+            },
+            "require": {
+                "composer/installers": "^1.0"
+            },
+            "type": "wordpress-plugin",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-only"
+            ],
+            "description": "Automatically copies media uploads to a storage provider's bucket for delivery. Optionally configure a CDN for even faster delivery.",
+            "homepage": "https://github.com/deliciousbrains/wp-amazon-s3-and-cloudfront",
+            "keywords": [
+                "amazon-web-services",
+                "cdn",
+                "cloudfront",
+                "digitalocean",
+                "plugin",
+                "s3",
+                "spaces"
+            ],
+            "support": {
+                "issues": "https://github.com/deliciousbrains/wp-amazon-s3-and-cloudfront/issues",
+                "source": "https://github.com/deliciousbrains/wp-amazon-s3-and-cloudfront/tree/3.2.11"
+            },
+            "time": "2025-01-22T10:09:23+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/deploy/config/init/fpm-start.sh
+++ b/deploy/config/init/fpm-start.sh
@@ -3,6 +3,49 @@
 if wp core is-installed 2>/dev/null; then
     # WP is installed.
     wp sync-user-roles sync
+
+    # Start temporary code to ensure that one of the Amazon S3 and Cloudfront plugins is activated.
+    # This is a temporary solution until wp-amazon-s3-and-cloudfront passes QA, and then we can
+    # move it to mu-plugins.
+
+    AS3C_IS_ACTIVATED=false
+    AS3C_IS_INSTALLED=false
+    AS3CP_IS_INSTALLED=false
+    AS3CP_IS_ACTIVATED=false
+    AS3C_PLUGIN_TO_ACTIVATE=false
+
+    # Check if wp-amazon-s3-and-cloudfront plugin is installed, update the AS3C_PLUGIN_TO_ACTIVATE variable accordingly.
+    if wp plugin is-installed wp-amazon-s3-and-cloudfront 2>/dev/null; then
+        AS3C_PLUGIN_TO_ACTIVATE=wp-amazon-s3-and-cloudfront
+        echo 'wp-amazon-s3-and-cloudfront plugin is installed.'
+    fi
+
+    # Check if wp-amazon-s3-and-cloudfront plugin is activated and set it as a variable: AS3C_IS_ACTIVATED
+    if wp plugin is-active wp-amazon-s3-and-cloudfront 2>/dev/null; then
+        AS3C_IS_ACTIVATED=true
+        echo 'wp-amazon-s3-and-cloudfront plugin is activated.'
+    fi
+
+    # Check if amazon-s3-and-cloudfront-pro plugin is installed, update the AS3C_PLUGIN_TO_ACTIVATE variable accordingly.
+    if wp plugin is-installed amazon-s3-and-cloudfront-pro 2>/dev/null; then
+        AS3C_PLUGIN_TO_ACTIVATE=amazon-s3-and-cloudfront-pro
+        echo 'amazon-s3-and-cloudfront-pro plugin is installed.'
+    fi
+
+    # Check if amazon-s3-and-cloudfront-pro plugin is activated and set it as a variable. AS3CP_IS_ACTIVATED
+    if wp plugin is-active amazon-s3-and-cloudfront-pro 2>/dev/null; then
+        AS3CP_IS_ACTIVATED=true
+        echo 'amazon-s3-and-cloudfront-pro plugin is activated.'
+    fi
+
+    # If both AS3CP_IS_ACTIVATED and AS3C_IS_ACTIVATED are false, then activate the desired plugin.
+    if [ "$AS3CP_IS_ACTIVATED" = false ] && [ "$AS3C_IS_ACTIVATED" = false ]; then
+        wp plugin activate $AS3C_PLUGIN_TO_ACTIVATE
+        echo "$AS3C_PLUGIN_TO_ACTIVATE plugin is activated."
+    fi
+
+    # End temporary code to ensure that one of the Amazon S3 and Cloudfront plugins is activated.
+
 else
     # Fallback if WP is not installed.
     # This will happen during a first run on localhost.

--- a/public/app/themes/clarity/inc/amazon-s3-and-cloudfront-assets.php
+++ b/public/app/themes/clarity/inc/amazon-s3-and-cloudfront-assets.php
@@ -2,6 +2,7 @@
 
 namespace DeliciousBrains\WP_Offload_Media\Tweaks;
 
+use Amazon_S3_And_CloudFront;
 use Amazon_S3_And_CloudFront_Pro;
 use Exception;
 use Roots\WPConfig\Config;
@@ -23,7 +24,7 @@ class AmazonS3AndCloudFrontAssets
     private string $cloudfront_host;
     private string $cloudfront_asset_url;
 
-    private Amazon_S3_And_CloudFront_Pro $as3cf;
+    private Amazon_S3_And_CloudFront|Amazon_S3_And_CloudFront_Pro $as3cf;
 
     public function __construct()
     {
@@ -50,6 +51,7 @@ class AmazonS3AndCloudFrontAssets
         // Set the CloudFront asset URL.
         $this->cloudfront_asset_url = $cloudfront_scheme . '://' . $this->cloudfront_host . '/build/' . $this->image_tag;
 
+        add_action('as3cf_ready', [$this, 'setAs3cfInstance']);
         add_action('as3cf_pro_ready', [$this, 'setAs3cfInstance']);
         add_action('init', [$this, 'init']);
         add_filter('style_loader_src', [$this, 'rewriteSrc'], 10, 2);
@@ -58,9 +60,9 @@ class AmazonS3AndCloudFrontAssets
     }
 
     /**
-     * Set the Amazon_S3_And_CloudFront_Pro instance.
+     * Set the Amazon_S3_And_CloudFront(_Pro) instance.
      * 
-     * @param Amazon_S3_And_CloudFront_Pro $as3cf_instance
+     * @param Amazon_S3_And_CloudFront|Amazon_S3_And_CloudFront_Pro $as3cf_instance
      * @return void
      */
 


### PR DESCRIPTION
This PR:

- Removes WP Media Offload Pro from the mu-plugins folder, to plugins.
- Installs WP Media Offload Lite to the plugins folder.
- Adds code to the fpm container startup script, to ensure at least one of the WP Media Offload plugins is active.
- Adds theme compatibility for the Lite version.