### PR TITLE
CDPT-2620 Cleanup after WP Offload Media downgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,6 @@
         "wpackagist-plugin/query-monitor": "^3.15",
         "wpackagist-plugin/debug-bar": "^1.1",
         "wpackagist-plugin/debug-bar-elasticpress": "^3.1",
-        "deliciousbrains-plugin/wp-offload-media": "^3.2",
         "stayallive/wp-sentry": "^7.11",
         "ext-mysqli": "*",
         "ext-openssl": "*",
@@ -101,6 +100,7 @@
         "installer-paths": {
             "public/app/mu-plugins/{$name}/": [
                 "type:wordpress-muplugin",
+                "deliciousbrains/wp-amazon-s3-and-cloudfront",
                 "ministryofjustice/wp-moj-elasticsearch",
                 "ministryofjustice/php-markdown-extra",
                 "wpackagist-plugin/wp-document-revisions",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b1e965e73f9251d61ce6905fa9563b03",
+    "content-hash": "3452f27414b260b46cef81c270922a59",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -575,21 +575,6 @@
                 }
             ],
             "time": "2024-09-19T14:15:21+00:00"
-        },
-        {
-            "name": "deliciousbrains-plugin/wp-offload-media",
-            "version": "3.2.8",
-            "dist": {
-                "type": "zip",
-                "url": "https://composer.deliciousbrains.com/?wc-api=delicious-brains&request=composer_download&package=wp-offload-media&version=3.2.8"
-            },
-            "require": {
-                "composer/installers": "~1.0 || ~2.0"
-            },
-            "type": "wordpress-plugin",
-            "extra": {
-                "installer-name": "amazon-s3-and-cloudfront-pro"
-            }
         },
         {
             "name": "deliciousbrains/wp-amazon-s3-and-cloudfront",

--- a/deploy/config/init/fpm-start.sh
+++ b/deploy/config/init/fpm-start.sh
@@ -3,49 +3,6 @@
 if wp core is-installed 2>/dev/null; then
     # WP is installed.
     wp sync-user-roles sync
-
-    # Start temporary code to ensure that one of the Amazon S3 and Cloudfront plugins is activated.
-    # This is a temporary solution until wp-amazon-s3-and-cloudfront passes QA, and then we can
-    # move it to mu-plugins.
-
-    AS3C_IS_ACTIVATED=false
-    AS3C_IS_INSTALLED=false
-    AS3CP_IS_INSTALLED=false
-    AS3CP_IS_ACTIVATED=false
-    AS3C_PLUGIN_TO_ACTIVATE=false
-
-    # Check if wp-amazon-s3-and-cloudfront plugin is installed, update the AS3C_PLUGIN_TO_ACTIVATE variable accordingly.
-    if wp plugin is-installed wp-amazon-s3-and-cloudfront 2>/dev/null; then
-        AS3C_PLUGIN_TO_ACTIVATE=wp-amazon-s3-and-cloudfront
-        echo 'wp-amazon-s3-and-cloudfront plugin is installed.'
-    fi
-
-    # Check if wp-amazon-s3-and-cloudfront plugin is activated and set it as a variable: AS3C_IS_ACTIVATED
-    if wp plugin is-active wp-amazon-s3-and-cloudfront 2>/dev/null; then
-        AS3C_IS_ACTIVATED=true
-        echo 'wp-amazon-s3-and-cloudfront plugin is activated.'
-    fi
-
-    # Check if amazon-s3-and-cloudfront-pro plugin is installed, update the AS3C_PLUGIN_TO_ACTIVATE variable accordingly.
-    if wp plugin is-installed amazon-s3-and-cloudfront-pro 2>/dev/null; then
-        AS3C_PLUGIN_TO_ACTIVATE=amazon-s3-and-cloudfront-pro
-        echo 'amazon-s3-and-cloudfront-pro plugin is installed.'
-    fi
-
-    # Check if amazon-s3-and-cloudfront-pro plugin is activated and set it as a variable. AS3CP_IS_ACTIVATED
-    if wp plugin is-active amazon-s3-and-cloudfront-pro 2>/dev/null; then
-        AS3CP_IS_ACTIVATED=true
-        echo 'amazon-s3-and-cloudfront-pro plugin is activated.'
-    fi
-
-    # If both AS3CP_IS_ACTIVATED and AS3C_IS_ACTIVATED are false, then activate the desired plugin.
-    if [ "$AS3CP_IS_ACTIVATED" = false ] && [ "$AS3C_IS_ACTIVATED" = false ]; then
-        wp plugin activate $AS3C_PLUGIN_TO_ACTIVATE
-        echo "$AS3C_PLUGIN_TO_ACTIVATE plugin is activated."
-    fi
-
-    # End temporary code to ensure that one of the Amazon S3 and Cloudfront plugins is activated.
-
 else
     # Fallback if WP is not installed.
     # This will happen during a first run on localhost.

--- a/public/app/themes/clarity/inc/amazon-s3-and-cloudfront-assets.php
+++ b/public/app/themes/clarity/inc/amazon-s3-and-cloudfront-assets.php
@@ -3,15 +3,8 @@
 namespace DeliciousBrains\WP_Offload_Media\Tweaks;
 
 use Amazon_S3_And_CloudFront;
-use Amazon_S3_And_CloudFront_Pro;
 use Exception;
 use Roots\WPConfig\Config;
-
-// If we are using the CLI, there is a chance that during plugin switchover that neither
-// Lite or Pro versions of the plugin are active. In this case, we should return early.
-if (defined('WP_CLI') && WP_CLI) {
-    return;
-}
 
 /**
  * Amazon S3 and CloudFront - assets.
@@ -30,7 +23,7 @@ class AmazonS3AndCloudFrontAssets
     private string $cloudfront_host;
     private string $cloudfront_asset_url;
 
-    private Amazon_S3_And_CloudFront|Amazon_S3_And_CloudFront_Pro $as3cf;
+    private Amazon_S3_And_CloudFront $as3cf;
 
     public function __construct()
     {
@@ -58,7 +51,6 @@ class AmazonS3AndCloudFrontAssets
         $this->cloudfront_asset_url = $cloudfront_scheme . '://' . $this->cloudfront_host . '/build/' . $this->image_tag;
 
         add_action('as3cf_ready', [$this, 'setAs3cfInstance']);
-        add_action('as3cf_pro_ready', [$this, 'setAs3cfInstance']);
         add_action('init', [$this, 'init']);
         add_filter('style_loader_src', [$this, 'rewriteSrc'], 10, 2);
         add_filter('script_loader_src', [$this, 'rewriteSrc'], 10, 2);
@@ -66,9 +58,9 @@ class AmazonS3AndCloudFrontAssets
     }
 
     /**
-     * Set the Amazon_S3_And_CloudFront(_Pro) instance.
+     * Set the Amazon_S3_And_CloudFront instance.
      * 
-     * @param Amazon_S3_And_CloudFront|Amazon_S3_And_CloudFront_Pro $as3cf_instance
+     * @param Amazon_S3_And_CloudFront $as3cf_instance
      * @return void
      */
 


### PR DESCRIPTION
The PR:

- Removes the Pro version
- Makes the Lite version a mu-plugin
- Deletes the startup script that ensures one or the other is active
- Tidies up the theme file [amazon-s3-and-cloudfront-assets.php](https://github.com/ministryofjustice/intranet/compare/cdpt-2620-cleanup-post-wp-medie-offload-downgrade?expand=1#diff-ef4108f8b95f073f315da5c37c28de8dc56d90d581b080bc1c2591efc58f7df2)

Merge this PR after we are happy that the Lite version is working 100%.