### PR TITLE
Run CodeQL on push to main.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,8 @@ name: "CodeQL"
 on:
   pull_request:
     branches: [ "main" ]
+  push:
+    branches: [ "main" ]
   schedule:
     - cron: '12 8 * * 2'
 


### PR DESCRIPTION
This PR addresses the `Unable to validate code scanning workflow: MissingPushHook` warning shown here: https://github.com/ministryofjustice/intranet/actions/runs/15159460720