### PR TITLE
Scale unused demo environment to zero `demo/deployment.tpl.yml`

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -316,6 +316,33 @@ To verify that S3 & CloudFront are working correctly.
 - The img source domain should be CloudFront.
 - Directly trying to access an image via the S3 bucket url should return an access denied message.
 
+## Deployment to Cloud Platform
+
+This application is deployed to MoJ Cloud Platform, using GitHub Actions.
+
+The relevant workflows can be found at:
+
+- [.github/workflows/integration.yml](./.github/workflows/integration.yml)
+- [.github/workflows/ip-ranges-configure.yml](/.github/workflows/ip-ranges-configure.yml)
+- [.github/workflows/modsec-config.yml](/.github/workflows/modsec-config.yml)
+- [.github/workflows/build.yml](/.github/workflows/build.yml)
+- [.github/workflows/deploy.yml](/.github/workflows/deploy.yml)
+
+Kubernetes manifests are located in the [deploy](/deploy) directory.
+
+There is a sub directory for each of the Cloud Platform environments: 
+
+- [development](/deploy/development)
+- [demo](/deploy/demo)
+- [staging](/deploy/staging)
+- [production](/deploy/production)
+
+> [!NOTE]
+> While not in use, the demo environment has been scaled to zero, and the workflow is not run.  
+> To scale up the demo environment, update the demo deployment manifest, and the integration workflow:
+> - [deploy/demo/deployment.tpl.yml](/deploy/demo/deployment.tpl.yml)
+> - [.github/workflows/integration.yml](/.github/workflows/integration.yml)
+
 ## Azure Setup
 
 ### Useful links

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - 'main'
 
+env:
+  # Demo environment is scaled to, and hence does not need to be deployed
+  # See README.md section: 'Deployment to Cloud Platform'
+  DISABLE_DEMO_DEPLOY: "true"
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -56,7 +61,7 @@ jobs:
   deploy_demo:
     name: "Demo"
     needs: [image, deploy_dev, get_ip_ranges, modsec_config]
-    if: github.event.ref == 'refs/heads/main'
+    if: env.DISABLE_DEMO_DEPLOY != 'true' && github.event.ref == 'refs/heads/main'
     uses: ./.github/workflows/deploy.yml
     with:
       environment: demo

--- a/deploy/demo/deployment.tpl.yml
+++ b/deploy/demo/deployment.tpl.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: ${KUBE_NAMESPACE}
 spec:
+  # Scaled to zero, see README.md section: 'Deployment to Cloud Platform'
   replicas: 0
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
As demo isn't regularly deployed, it is running old docker images, and these will contain outdated dependencies.

Since we are not currently using the demo environment, let's scale it to zero.