### PR TITLE
Redirect traffic for jac.intranet.service.justice.gov.uk to intranet.justice.gov.uk/?agency=jac

### DIFF
--- a/deploy/production/ingress.tpl.yml
+++ b/deploy/production/ingress.tpl.yml
@@ -13,6 +13,10 @@ metadata:
     # Set vhost so that WP doesn't see prod-intranet.apps... and redirect.
     nginx.ingress.kubernetes.io/upstream-vhost: intranet.justice.gov.uk
     nginx.ingress.kubernetes.io/server-snippet: |
+      # Redirect requests for legacy JAC intranet to /?agency=jac
+      if ($host = 'jac.intranet.service.justice.gov.uk') {
+        return 301 https://intranet.justice.gov.uk/?agency=jac;
+      }
       location = /health {
         auth_basic off;
         access_log off;


### PR DESCRIPTION
Related:

- https://github.com/ministryofjustice/cloud-platform-environments/pull/33736
- https://github.com/ministryofjustice/cloud-platform-environments/pull/33737

The redirect uses a the syntax that is used in the dev ingress.

https://github.com/ministryofjustice/intranet/blob/e72e6356382177c37f9e67071a2bc0a7cd40e385/deploy/development/ingress.tpl.yml#L14