### PR TITLE
Handle rollout period where a user may have new js, but old server side html.

### DIFF
--- a/public/app/themes/clarity/src/globals/js/auth-heartbeat.js
+++ b/public/app/themes/clarity/src/globals/js/auth-heartbeat.js
@@ -10,7 +10,7 @@ export default (function ($) {
             value: 'user_accepted',
             set: (value, days = 7) => {
                 const expires = new Date( Date.now() + days * 864e5).toUTCString()
-                const maybeSecure = window.mojAuthHeartbeat.https ? 'secure' : ''
+                const maybeSecure = window.mojAuthHeartbeat?.https ? 'secure' : ''
                 document.cookie = `${Backdrop.cookie.name}=${value}; expires=${expires}; path=/; ${maybeSecure}`
             },
             get: () => {


### PR DESCRIPTION
This is a follow on PR for https://github.com/ministryofjustice/intranet/pull/867

It fixes a bug where a user could have new JS but old html from the server. And an error will occur saying mojAuthHeartbeat is undefined.