### PR TITLE
CDPT-2950 Fix date rounding bug.

### DIFF
--- a/public/app/themes/clarity/src/components/c-content-filter/view-events.php
+++ b/public/app/themes/clarity/src/components/c-content-filter/view-events.php
@@ -23,8 +23,6 @@ $prefix = 'ff';
               // So that we don't get rounding errors when adding months.
               $base_timestamp = strtotime("15 " . date('F Y'));
 
-              $base_timestamp = strtotime("31 July 2024");
-
               while ($m <= 12) {
                 $next_month = date('Y-m', strtotime('+' . $m . 'months', $base_timestamp));
                 $human_date = date('F Y', strtotime('+' . $m . 'months', $base_timestamp));

--- a/public/app/themes/clarity/src/components/c-content-filter/view-events.php
+++ b/public/app/themes/clarity/src/components/c-content-filter/view-events.php
@@ -5,6 +5,10 @@ if (! defined('ABSPATH')) {
 }
 
 $prefix = 'ff';
+
+// Set an initial date as the 15th of the current month.
+// So that we don't get rounding errors when adding months.
+$ff_date = new DateTime(date('Y-m-\1\5'));
 ?>
 
 <!-- c-content-filter starts here -->
@@ -16,20 +20,12 @@ $prefix = 'ff';
         <label for="ff_date_filter">Date</label>
           <select name="ff_date_filter" id="ff_date_filter" >
             <option value="all"><?= esc_attr(__('All')) ?></option>
-            <?php
-              $m = 0;
 
-              // Set a base timestamp as the 15th of the current month.
-              // So that we don't get rounding errors when adding months.
-              $base_timestamp = strtotime("15 " . date('F Y'));
+            <?php for ($m = 0 ; $m <= 12; $m++) : ?>
+              <option value="<?= $ff_date->format('Y-m') ?>"><?= $ff_date->format('F Y') ?></option>
+              <?php $ff_date->modify('+ 1 month'); ?>
+            <?php endfor; ?>
 
-              while ($m <= 12) {
-                $next_month = date('Y-m', strtotime('+' . $m . 'months', $base_timestamp));
-                $human_date = date('F Y', strtotime('+' . $m . 'months', $base_timestamp));
-                echo '<option value=' . $next_month . '>' . $human_date . '</option>';
-                $m++;
-              }
-            ?>
         </select>
       </div>
       <?php

--- a/public/app/themes/clarity/src/components/c-content-filter/view-events.php
+++ b/public/app/themes/clarity/src/components/c-content-filter/view-events.php
@@ -19,9 +19,15 @@ $prefix = 'ff';
             <?php
               $m = 0;
 
+              // Set a base timestamp as the 15th of the current month.
+              // So that we don't get rounding errors when adding months.
+              $base_timestamp = strtotime("15 " . date('F Y'));
+
+              $base_timestamp = strtotime("31 July 2024");
+
               while ($m <= 12) {
-                $next_month = date('Y-m', strtotime('+' . $m . 'months'));
-                $human_date = date('F Y', strtotime('+' . $m . 'months'));
+                $next_month = date('Y-m', strtotime('+' . $m . 'months', $base_timestamp));
+                $human_date = date('F Y', strtotime('+' . $m . 'months', $base_timestamp));
                 echo '<option value=' . $next_month . '>' . $human_date . '</option>';
                 $m++;
               }

--- a/public/app/themes/clarity/src/components/c-content-filter/view-region-events.php
+++ b/public/app/themes/clarity/src/components/c-content-filter/view-region-events.php
@@ -19,9 +19,13 @@ $prefix = 'ff';
             <?php
             $m = 0;
 
+            // Set a base timestamp as the 15th of the current month.
+            // So that we don't get rounding errors when adding months.
+            $base_timestamp = strtotime("15 " . date('F Y'));
+
             while ($m <= 12) {
-                $next_month = date('Y-m', strtotime('+' . $m . 'months'));
-                $human_date = date('F Y', strtotime('+' . $m . 'months'));
+                $next_month = date('Y-m', strtotime('+' . $m . 'months', $base_timestamp));
+                $human_date = date('F Y', strtotime('+' . $m . 'months', $base_timestamp));
                 echo '<option value=' . $next_month . '>' . $human_date . '</option>';
                 $m++;
             }

--- a/public/app/themes/clarity/src/components/c-content-filter/view-region-events.php
+++ b/public/app/themes/clarity/src/components/c-content-filter/view-region-events.php
@@ -5,6 +5,10 @@ if (! defined('ABSPATH')) {
 }
 
 $prefix = 'ff';
+
+// Set an initial date as the 15th of the current month.
+// So that we don't get rounding errors when adding months.
+$ff_date = new DateTime(date('Y-m-\1\5'));
 ?>
 
 <!-- c-content-filter starts here -->
@@ -16,20 +20,12 @@ $prefix = 'ff';
         <label for="ff_date_filter">Date</label>
         <select name="ff_date_filter" id="ff_date_filter" >
           <option value="all"><?= esc_attr(__('All')) ?></option>
-            <?php
-            $m = 0;
 
-            // Set a base timestamp as the 15th of the current month.
-            // So that we don't get rounding errors when adding months.
-            $base_timestamp = strtotime("15 " . date('F Y'));
+          <?php for ($m = 0 ; $m <= 12; $m++) : ?>
+            <option value="<?= $ff_date->format('Y-m') ?>"><?= $ff_date->format('F Y') ?></option>
+            <?php $ff_date->modify('+ 1 month'); ?>
+          <?php endfor; ?>
 
-            while ($m <= 12) {
-                $next_month = date('Y-m', strtotime('+' . $m . 'months', $base_timestamp));
-                $human_date = date('F Y', strtotime('+' . $m . 'months', $base_timestamp));
-                echo '<option value=' . $next_month . '>' . $human_date . '</option>';
-                $m++;
-            }
-            ?>
         </select>
       </div>
       <?php

--- a/public/app/themes/clarity/src/components/c-content-filter/view-regions.php
+++ b/public/app/themes/clarity/src/components/c-content-filter/view-regions.php
@@ -19,9 +19,13 @@ $prefix = 'ff';
             <?php
               $m = 0;
 
+              // Set a base timestamp as the 15th of the current month.
+              // So that we don't get rounding errors when adding months.
+              $base_timestamp = strtotime("15 " . date('F Y'));
+
               while ($m <= 12) {
-                  $next_month = date('Y-m', strtotime('+' . $m . 'months'));
-                  $human_date = date('F Y', strtotime('+' . $m . 'months'));
+                  $next_month = date('Y-m', strtotime('+' . $m . 'months', $base_timestamp));
+                  $human_date = date('F Y', strtotime('+' . $m . 'months', $base_timestamp));
                   echo '<option value=' . $next_month . '>' . $human_date . '</option>';
                   $m++;
               }

--- a/public/app/themes/clarity/src/components/c-content-filter/view-regions.php
+++ b/public/app/themes/clarity/src/components/c-content-filter/view-regions.php
@@ -5,6 +5,10 @@ if (! defined('ABSPATH')) {
 }
 
 $prefix = 'ff';
+
+// Set an initial date as the 15th of the current month.
+// So that we don't get rounding errors when adding months.
+$ff_date = new DateTime(date('Y-m-\1\5'));
 ?>
 
 <!-- c-content-filter starts here -->
@@ -16,20 +20,12 @@ $prefix = 'ff';
         <label for="ff_date_filter">Date</label>
         <select name="ff_date_filter" id="ff_date_filter" >
           <option value="all"><?= esc_attr(__('All')) ?></option>
-            <?php
-              $m = 0;
 
-              // Set a base timestamp as the 15th of the current month.
-              // So that we don't get rounding errors when adding months.
-              $base_timestamp = strtotime("15 " . date('F Y'));
+          <?php for ($m = 0 ; $m <= 12; $m++) : ?>
+            <option value="<?= $ff_date->format('Y-m') ?>"><?= $ff_date->format('F Y') ?></option>
+            <?php $ff_date->modify('+ 1 month'); ?>
+          <?php endfor; ?>
 
-              while ($m <= 12) {
-                  $next_month = date('Y-m', strtotime('+' . $m . 'months', $base_timestamp));
-                  $human_date = date('F Y', strtotime('+' . $m . 'months', $base_timestamp));
-                  echo '<option value=' . $next_month . '>' . $human_date . '</option>';
-                  $m++;
-              }
-            ?>
         </select>
       </div>
       <?php


### PR DESCRIPTION
Months were not rendering correctly when the current day was the 31st of a month.

e.g. July 31st plus 2 months is October and July 31st plus 3 months is also October

The fix was to set a base timestamp as the 15th of the current month, this way we don't get rounding errors when adding months.

Reference https://www.php.net/manual/en/function.strtotime.php