### PR TITLE
QA tagging amend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,10 @@ name: "CI Build"
 
 on:
   workflow_call:
+    inputs:
+      pipeline:
+        required: true
+        type: string
     outputs:
       registry:
         description: "AWS registry where the ECR is located"


### PR DESCRIPTION
Should fix error:

```
The workflow is not valid. .github/workflows/integration.yml (Line: 20, Col: 17): Invalid input, pipeline is not defined in the referenced workflow.
```