### PR TITLE
CDPTKAN-287 Update packages (amend to require env file)

### DIFF
--- a/public/metrics/service.php
+++ b/public/metrics/service.php
@@ -2,6 +2,7 @@
 
 namespace MOJ\Intranet;
 
+require_once dirname(__DIR__) . '../../config/env.php';
 require_once dirname(__DIR__) . '../../vendor/autoload.php';
 
 use GuzzleHttp;


### PR DESCRIPTION
This fixes an oversight in the previous PR, where the env function was not available to the metrics class.