### PR TITLE
Add Agency - Wales Office

### DIFF
--- a/public/app/themes/clarity/inc/agency.php
+++ b/public/app/themes/clarity/inc/agency.php
@@ -167,6 +167,14 @@ class Agency
                     ]
                 ]
             ],
+            'wales-office' => [
+                'shortcode' => 'wales-office',
+                'label' => 'Wales Office',
+                'abbreviation' => 'WO',
+                'is_integrated' => true,
+                'contact_email_address' => 'Director@ukgovwales.gov.uk',
+                'links' => []
+            ],
             'yjbrh' => [
                 'shortcode' => 'yjbrh',
                 'label' => 'Youth Justice Board Resource Hub',

--- a/public/app/themes/clarity/inc/menu.php
+++ b/public/app/themes/clarity/inc/menu.php
@@ -29,4 +29,5 @@ function register_my_menu()
     register_nav_menu('ppo-menu', __('PPO Menu'));
     register_nav_menu('ospt-menu', __('OSPT Menu'));
     register_nav_menu('jac-menu', __('JAC Menu'));
+    register_nav_menu('wales-office-menu', __('WO Menu'));
 }

--- a/public/app/themes/clarity/src/components/c-global-header/view-wales-office.php
+++ b/public/app/themes/clarity/src/components/c-global-header/view-wales-office.php
@@ -1,0 +1,5 @@
+<?php
+  $agency_colour    = '#97393c';
+  $agency_title     = 'Wales Office';
+  $agency_shortcode = 'wales-office';
+  require_once 'base-header.php';

--- a/public/app/themes/clarity/src/components/c-intranet-switcher/view.php
+++ b/public/app/themes/clarity/src/components/c-intranet-switcher/view.php
@@ -16,7 +16,7 @@ if (isset($_GET['send_back'])) {
 
 // Temporarily filtering out JAC/PB until site is ready to go live
 // 10th Jan 2024: Parole Board added to exclude list: https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1154?selectedIssue=CDPT-1170
-$excluded = ['pb'];
+$excluded = ['pb', 'wales-office'];
 $integrated = [];
 $external = [];
 

--- a/public/app/themes/clarity/src/components/c-rich-text-block/style.styl
+++ b/public/app/themes/clarity/src/components/c-rich-text-block/style.styl
@@ -104,6 +104,15 @@ img.aligncenter { display: block; margin-left: auto; margin-right: auto; }
   }
 }
 
+.agency-wales-office & {
+  .c-rich-text-block {
+    blockquote {
+      border-left: 10px solid $wo_primary;
+    }
+  }
+}
+
+
 .clarity-responsive-table {
   overflow-x: auto;
 }

--- a/public/app/themes/clarity/src/components/c-search-bar/style.styl
+++ b/public/app/themes/clarity/src/components/c-search-bar/style.styl
@@ -108,6 +108,11 @@
     .agency-ppo & {
       background-color: $ppo_primary;
     }
+
+    .agency-wales-office & {
+      background-color: $wo_primary;
+    }
+
   }
 
 }

--- a/public/app/themes/clarity/src/globals/css/_variables.styl
+++ b/public/app/themes/clarity/src/globals/css/_variables.styl
@@ -62,3 +62,4 @@ $opg_primary    = #00838F;
 $pb_primary     = #ab0755;
 $ppo_primary    = $defaultAgencyColour;
 $laa_primary    = #156c60;
+$wo_primary    = #97393c;


### PR DESCRIPTION
# Add Wales Office as a new agency (hidden until launch)

## Summary

Registers **Wales Office** as a new integrated agency in the intranet theme — agency config, branded header, and colour styling — and keeps it hidden from the public agency switcher until it's ready to go live.

## Changes

- **`inc/agency.php`** — added a `wales-office` entry to `Agency::getList()`:
  - label: `Wales Office`, abbreviation: `WO`
  - `is_integrated => true`
  - `contact_email_address => Director@ukgovwales.gov.uk`
  - no custom links yet
- **`src/components/c-global-header/view-wales-office.php`** *(new)* — header variant for the agency: colour `#97393c`, title `Wales Office`, shortcode `wales-office`
- **`src/globals/css/_variables.styl`** — added `$wo_primary = #97393c` brand colour variable
- **`src/components/c-rich-text-block/style.styl`** — added `.agency-wales-office` rule for blockquote border colour
- **`src/components/c-search-bar/style.styl`** — added `.agency-wales-office` rule for background colour
- **`inc/whitelisted-emails.php`** — added `ukgovwales.gov.uk` and `walesoffice.gov.uk` to the valid sign-up email domains
- **`src/components/c-intranet-switcher/view.php`** — added `wales-office` to the `$excluded` array so it's hidden from the agency switcher for now (same pattern already used for Parole Board)
