### PR TITLE
Fix Homepage Options - featured blog posts showing all post types

### DIFF
--- a/public/app/themes/clarity/inc/admin/acf-field-group.php
+++ b/public/app/themes/clarity/inc/admin/acf-field-group.php
@@ -1754,7 +1754,9 @@
                 'id' => '',
             ),
             'admin_only' => 0,
-            'post_type' => '',
+            'post_type' => array(
+                0 => 'post',
+            ),
             'taxonomy' => '',
             'allow_null' => 0,
             'multiple' => 0,
@@ -1905,7 +1907,9 @@
                 'id' => '',
             ),
             'admin_only' => 0,
-            'post_type' => '',
+            'post_type' => array(
+                0 => 'post',
+            ),
             'taxonomy' => '',
             'allow_null' => 0,
             'multiple' => 0,
@@ -3140,7 +3144,9 @@
                 'id' => '',
             ),
             'admin_only' => 0,
-            'post_type' => '',
+            'post_type' => array(
+                0 => 'post',
+            ),
             'taxonomy' => '',
             'allow_null' => 0,
             'multiple' => 0,
@@ -3291,7 +3297,9 @@
                 'id' => '',
             ),
             'admin_only' => 0,
-            'post_type' => '',
+            'post_type' => array(
+                0 => 'page',
+            ),
             'taxonomy' => '',
             'allow_null' => 0,
             'multiple' => 0,

--- a/public/app/themes/clarity/inc/admin/acf-field-group.php
+++ b/public/app/themes/clarity/inc/admin/acf-field-group.php
@@ -3298,7 +3298,7 @@
             ),
             'admin_only' => 0,
             'post_type' => array(
-                0 => 'page',
+                0 => 'post',
             ),
             'taxonomy' => '',
             'allow_null' => 0,


### PR DESCRIPTION
The Homepage featured item options was showing all post types since the Wordpress Update 7.0.2.  This now restricts it to just blog posts