### PR TITLE
Fix elasticpress cache poisoning - update to 5.3.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "ministryofjustice/php-markdown-extra": "dev-main",
         "ministryofjustice/wp-moj-components": "^3.5",
         "ministryofjustice/wp-moj-elasticsearch": "^2.3.0",
-        "wpackagist-plugin/elasticpress": "^5.3",
+        "wpackagist-plugin/elasticpress": "^5.3.4",
         "alphagov/notifications-php-client": "^7.0",
         "wpackagist-plugin/query-monitor": "^4.0",
         "wpackagist-plugin/debug-bar": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b25078c4cbebafe52f016959c3740116",
+    "content-hash": "126759a596cd6e32a143880b58add472",
     "packages": [
         {
             "name": "alphagov/notifications-php-client",
@@ -3662,15 +3662,15 @@
         },
         {
             "name": "wpackagist-plugin/elasticpress",
-            "version": "5.3.3",
+            "version": "5.3.4",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/elasticpress/",
-                "reference": "tags/5.3.3"
+                "reference": "tags/5.3.4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/elasticpress.5.3.3.zip"
+                "url": "https://downloads.wordpress.org/plugin/elasticpress.5.3.4.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"

--- a/public/app/themes/clarity/inc/admin/plugins/wp-elasticsearch.php
+++ b/public/app/themes/clarity/inc/admin/plugins/wp-elasticsearch.php
@@ -32,6 +32,56 @@ class WPElasticPress
         add_filter('ep_search_post_return_args', [$this, 'removeUnsetFields']);
 
         add_filter('ep_formatted_args', [$this, 'removeFilterWeightRecent'], 12, 2);
+
+        add_action('pre_get_posts', [$this, 'disableCacheResults'], 6);
+    }
+
+    /**
+     * Stop ElasticPress-served posts from poisoning the WordPress post cache.
+     *
+     * ES-served posts are built from the Elasticsearch _source, so any column
+     * missing from it falls back to the WP_Post default. `post_parent` is one:
+     * MOJElasticSearch\ElasticPressHooks::removePostArgs unsets it before
+     * indexing, so every ES-served post arrives with `post_parent = 0`. Same
+     * goes for the other columns stripped there and in self::REMOVE_FIELDS.
+     *
+     * With `cache_results` on, WP_Query hands those objects to
+     * update_post_caches(), which adds them to the persistent `posts` group.
+     * A later get_permalink() then builds a URL with no ancestor segments on
+     * pages that never went near search - a 404, or a link to the wrong page
+     * where the truncated path matches a real top-level one.
+     *
+     * ElasticPress did this itself up to 5.3.2, then dropped it in 5.3.3 to
+     * cache term and meta queries. That trade is unsafe while the index is
+     * missing columns, so this restores the old behaviour and its opt-in. The
+     * cost is re-priming term and meta caches per post on results pages.
+     *
+     * Index `post_parent` and this can go, along with the wrong values still
+     * read straight off posts in the search loop, which this does not fix.
+     *
+     * @see https://github.com/10up/ElasticPress/blob/5.3.2/includes/classes/Indexable/Post/QueryIntegration.php#L119-L127
+     *
+     * @param \WP_Query $query The query about to run.
+     * @return void
+     */
+    public function disableCacheResults($query): void
+    {
+        if (!class_exists('\\ElasticPress\\Indexables')) {
+            return;
+        }
+
+        $indexable = \ElasticPress\Indexables::factory()->get('post');
+
+        if (!$indexable || !$indexable->elasticpress_enabled($query)) {
+            return;
+        }
+
+        if (apply_filters('ep_skip_query_integration', false, $query)) {
+            return;
+        }
+
+        // Off by default, but honour an explicit opt-in from the caller.
+        $query->set('cache_results', !empty($query->query['cache_results']));
     }
 
     /**

--- a/public/app/themes/clarity/inc/admin/plugins/wp-elasticsearch.php
+++ b/public/app/themes/clarity/inc/admin/plugins/wp-elasticsearch.php
@@ -32,56 +32,6 @@ class WPElasticPress
         add_filter('ep_search_post_return_args', [$this, 'removeUnsetFields']);
 
         add_filter('ep_formatted_args', [$this, 'removeFilterWeightRecent'], 12, 2);
-
-        add_action('pre_get_posts', [$this, 'disableCacheResults'], 6);
-    }
-
-    /**
-     * Stop ElasticPress-served posts from poisoning the WordPress post cache.
-     *
-     * ES-served posts are built from the Elasticsearch _source, so any column
-     * missing from it falls back to the WP_Post default. `post_parent` is one:
-     * MOJElasticSearch\ElasticPressHooks::removePostArgs unsets it before
-     * indexing, so every ES-served post arrives with `post_parent = 0`. Same
-     * goes for the other columns stripped there and in self::REMOVE_FIELDS.
-     *
-     * With `cache_results` on, WP_Query hands those objects to
-     * update_post_caches(), which adds them to the persistent `posts` group.
-     * A later get_permalink() then builds a URL with no ancestor segments on
-     * pages that never went near search - a 404, or a link to the wrong page
-     * where the truncated path matches a real top-level one.
-     *
-     * ElasticPress did this itself up to 5.3.2, then dropped it in 5.3.3 to
-     * cache term and meta queries. That trade is unsafe while the index is
-     * missing columns, so this restores the old behaviour and its opt-in. The
-     * cost is re-priming term and meta caches per post on results pages.
-     *
-     * Index `post_parent` and this can go, along with the wrong values still
-     * read straight off posts in the search loop, which this does not fix.
-     *
-     * @see https://github.com/10up/ElasticPress/blob/5.3.2/includes/classes/Indexable/Post/QueryIntegration.php#L119-L127
-     *
-     * @param \WP_Query $query The query about to run.
-     * @return void
-     */
-    public function disableCacheResults($query): void
-    {
-        if (!class_exists('\\ElasticPress\\Indexables')) {
-            return;
-        }
-
-        $indexable = \ElasticPress\Indexables::factory()->get('post');
-
-        if (!$indexable || !$indexable->elasticpress_enabled($query)) {
-            return;
-        }
-
-        if (apply_filters('ep_skip_query_integration', false, $query)) {
-            return;
-        }
-
-        // Off by default, but honour an explicit opt-in from the caller.
-        $query->set('cache_results', !empty($query->query['cache_results']));
     }
 
     /**


### PR DESCRIPTION
elasticpress 5.3.3 introduced a bug where a partial result (without patent ID) for a post would be cached in object cache.

This would surface as a bug where search result URLs were missing the `/parent/pages/` part.

This update fixes that bug.